### PR TITLE
feat: Allow individual list of monikers per network 

### DIFF
--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -35,7 +35,7 @@ func Build(port string, l *logrus.Logger, cfg *config.MonitoringConfig, sc *conf
 	}
 
 	if app == common.VALIDATOR && len(cfg.Monikers) < 1 {
-		return nil, errors.New("in cosmostation-exporter mode, you must add monike into the moniker flag")
+		return nil, errors.New("in cosmostation-exporter mode, you must add moniker into the moniker flag")
 	}
 
 	registry.MustRegister(common.Skip, common.Health, common.Ops)

--- a/internal/app/exporter/register.go
+++ b/internal/app/exporter/register.go
@@ -24,6 +24,13 @@ func register(m common.Mode, f promauto.Factory, l *logrus.Logger, mc *config.Mo
 		packages := chain.Packages
 		protocolType := chain.ProtocolType
 		isConsumer := chain.Consumer
+		monikers := mc.Monikers
+		if cc.Monikers != nil {
+			l.Debugf("found individual moniker list: %v for chain: %v", cc.Monikers, chain.ChainName)
+			monikers = cc.Monikers
+		}
+
+		// get balance denomination and decimal
 
 		balanceDenom := chain.SupportAsset.Denom
 		balanceDecimal := chain.SupportAsset.Decimal
@@ -40,7 +47,7 @@ func register(m common.Mode, f promauto.Factory, l *logrus.Logger, mc *config.Mo
 			if ok := helper.Contains(common.ExporterPackages, pkg); ok {
 				if PackageFilter == "" {
 					// all package is going to register
-					err := selectPackage(m, f, l, mainnet, chainID, chainName, pkg, protocolType, balanceDenom, balanceDecimal, isConsumer, cc, mc.Monikers)
+					err := selectPackage(m, f, l, mainnet, chainID, chainName, pkg, protocolType, balanceDenom, balanceDecimal, isConsumer, cc, monikers)
 					if err != nil {
 						l.WithField("package", pkg).WithField("chain", cc.ChainID).Errorf("this package is skipped by %s", err)
 						common.Skip.With(prometheus.Labels{
@@ -54,7 +61,7 @@ func register(m common.Mode, f promauto.Factory, l *logrus.Logger, mc *config.Mo
 				} else if strings.Contains(string(pkg), PackageFilter) {
 					// specific package is going to register by 'PackageFilter' variable
 					l.Debugf("filterd package %s for %s", pkg, chainName)
-					err := selectPackage(m, f, l, mainnet, chainID, chainName, pkg, protocolType, balanceDenom, balanceDecimal, isConsumer, cc, mc.Monikers)
+					err := selectPackage(m, f, l, mainnet, chainID, chainName, pkg, protocolType, balanceDenom, balanceDecimal, isConsumer, cc, monikers)
 					if err != nil {
 						l.WithField("package", pkg).WithField("chain", chainName).Infof("this package is skipped by %s", err)
 						common.Skip.With(prometheus.Labels{

--- a/internal/app/indexer/indexer.go
+++ b/internal/app/indexer/indexer.go
@@ -24,7 +24,7 @@ func Build(port string, l *logrus.Logger, cfg *config.MonitoringConfig, sc *conf
 	}
 
 	if app == common.VALIDATOR && len(cfg.Monikers) < 1 {
-		return nil, errors.New("in cosmostation-exporter mode, you must add monike into the moniker flag")
+		return nil, errors.New("in cosmostation-exporter mode, you must add moniker into the moniker flag")
 	}
 
 	// register root metircs

--- a/internal/app/indexer/register.go
+++ b/internal/app/indexer/register.go
@@ -22,11 +22,17 @@ func register(m common.Mode, f promauto.Factory, l *logrus.Logger, idb *common.I
 		protocolType := chain.ProtocolType
 		isConsumer := chain.Consumer
 
+		monikers := mc.Monikers
+		if cc.Monikers != nil {
+			l.Debugf("found individual moniker list: %v for chain: %v", cc.Monikers, chain.ChainName)
+			monikers = cc.Monikers
+		}
+
 		for _, pkg := range packages {
 			// only register indexer packages among config packages
 			if ok := helper.Contains(common.IndexPackages, pkg); ok {
 				// all package is going to register
-				err := selectPackage(m, f, l, idb, mainnet, chainID, chainName, pkg, protocolType, isConsumer, cc, mc.Monikers)
+				err := selectPackage(m, f, l, idb, mainnet, chainID, chainName, pkg, protocolType, isConsumer, cc, monikers)
 				if err != nil {
 					l.WithField("package", pkg).WithField("chain", chainName).WithField("chain_id", chainID).
 						Errorf("this package was failed to start while initiating, so that the package will be skipped: %s", err)

--- a/internal/helper/config/config.go
+++ b/internal/helper/config/config.go
@@ -22,6 +22,7 @@ type ChainConfig struct {
 	TrackingAddresses []string       `yaml:"tracking_addresses,omitempty"`
 	Nodes             []NodeEndPoint `yaml:"nodes"`
 	ProviderNodes     []NodeEndPoint `yaml:"provider_nodes"`
+	Monikers          []string       `yaml:"monikers,omitempty"`
 }
 
 // each chain's available node list

--- a/internal/packages/consensus/uptime/collector/collector.go
+++ b/internal/packages/consensus/uptime/collector/collector.go
@@ -17,9 +17,6 @@ var (
 	_ common.CollectorLoop  = loop
 )
 
-// NOTE: this is for solo mode
-var packageMonikers []string
-
 const (
 	Subsystem                    = "uptime"
 	SubsystemSleep               = 10 * time.Second
@@ -32,7 +29,6 @@ const (
 
 func Start(p common.Packager) error {
 	if ok := helper.Contains(types.SupportedProtocolTypes, p.ProtocolType); ok {
-		packageMonikers = p.Monikers
 		exporter := common.NewExporter(p)
 		for _, rpc := range p.RPCs {
 			exporter.SetRPCEndPoint(rpc)
@@ -164,7 +160,7 @@ func loop(exporter *common.Exporter, p common.Packager) {
 		} else {
 			// update metrics by each validators
 			for _, item := range status.Validators {
-				if ok := helper.Contains(packageMonikers, item.Moniker); ok {
+				if ok := helper.Contains(p.Monikers, item.Moniker); ok {
 					uptimeMetric.
 						With(prometheus.Labels{
 							common.ValidatorAddressLabel: item.ValidatorOperatorAddress,

--- a/internal/packages/duty/axelar-evm/collector/collector.go
+++ b/internal/packages/duty/axelar-evm/collector/collector.go
@@ -19,9 +19,6 @@ var (
 	_ common.CollectorLoop  = loop
 )
 
-// NOTE: this is for solo mode
-var packageMonikers []string
-
 const (
 	Subsystem      = "axelar_evm"
 	SubsystemSleep = 60 * time.Second
@@ -33,7 +30,6 @@ const (
 
 func Start(p common.Packager) error {
 	if ok := helper.Contains(types.SupportedChains, p.ChainName); ok {
-		packageMonikers = p.Monikers
 		for _, api := range p.APIs {
 			exporter := common.NewExporter(p)
 			exporter.SetAPIEndPoint(api)
@@ -113,7 +109,7 @@ func loop(c *common.Exporter, p common.Packager) {
 		} else {
 			// filter metrics for only specific validator
 			for _, item := range status.Validators {
-				if ok := helper.Contains(packageMonikers, item.Moniker); ok {
+				if ok := helper.Contains(p.Monikers, item.Moniker); ok {
 					maintainerMetric.
 						With(prometheus.Labels{
 							common.ValidatorAddressLabel: item.ValidatorOperatorAddress,

--- a/internal/packages/duty/eventnonce/collector/collector.go
+++ b/internal/packages/duty/eventnonce/collector/collector.go
@@ -17,9 +17,6 @@ var (
 	_ common.CollectorLoop  = loop
 )
 
-// NOTE: this is for solo mode
-var packageMonikers []string
-
 const (
 	Subsystem      = "eventnonce"
 	SubsystemSleep = 60 * time.Second
@@ -31,7 +28,6 @@ const (
 
 func Start(p common.Packager) error {
 	if ok := helper.Contains(types.SupportedChains, p.ChainName); ok {
-		packageMonikers = p.Monikers
 		for _, baseURL := range p.GRPCs {
 			client := common.NewExporter(p)
 			client.SetGRPCEndPoint(baseURL)
@@ -115,7 +111,7 @@ func loop(c *common.Exporter, p common.Packager) {
 		} else {
 			// filter metrics for only specific validator
 			for _, item := range status.Validators {
-				if ok := helper.Contains(packageMonikers, item.Moniker); ok {
+				if ok := helper.Contains(p.Monikers, item.Moniker); ok {
 					eventNonceMetric.
 						With(prometheus.Labels{
 							common.ValidatorAddressLabel:    item.ValidatorOperatorAddress,

--- a/internal/packages/duty/oracle/collector/collector.go
+++ b/internal/packages/duty/oracle/collector/collector.go
@@ -18,9 +18,6 @@ var (
 	_ common.CollectorLoop  = loop
 )
 
-// NOTE: this is for solo mode
-var packageMonikers []string
-
 const (
 	Subsystem      = "oracle"
 	SubsystemSleep = 15 * time.Second
@@ -36,7 +33,6 @@ const (
 
 func Start(p common.Packager) error {
 	if ok := helper.Contains(types.SupportedChains, p.ChainName); ok {
-		packageMonikers = p.Monikers
 		for _, api := range p.APIs {
 			client := common.NewExporter(p)
 			client.SetAPIEndPoint(api)
@@ -139,7 +135,7 @@ func loop(c *common.Exporter, p common.Packager) {
 		} else {
 			// filter metrics for only specific validator
 			for _, item := range status.Validators {
-				if ok := helper.Contains(packageMonikers, item.Moniker); ok {
+				if ok := helper.Contains(p.Monikers, item.Moniker); ok {
 					missCounterMetric.
 						With(prometheus.Labels{
 							common.ValidatorAddressLabel: item.ValidatorOperatorAddress,

--- a/internal/packages/duty/yoda/collector/collector.go
+++ b/internal/packages/duty/yoda/collector/collector.go
@@ -19,9 +19,6 @@ var (
 	_ common.CollectorLoop  = loop
 )
 
-// NOTE: this is for solo mode
-var packageMonikers []string
-
 // Due to the nature of how request misses are tracked and counted,
 // the list of all misses collected in the previous iteration is kept in memory
 var yodaRequestMisses = make([]types.ValidatorStatus, 0)
@@ -68,7 +65,6 @@ const (
 func Start(p common.Packager) error {
 	if ok := helper.Contains(types.SupportedChains, p.ChainName); ok {
 		exporter := common.NewExporter(p)
-		packageMonikers = p.Monikers
 		for _, rpc := range p.RPCs {
 			exporter.SetRPCEndPoint(rpc)
 			break
@@ -210,7 +206,7 @@ func loop(c *common.Exporter, p common.Packager) {
 		} else {
 			// filter metrics for only specific validator
 			for _, item := range status.Validators {
-				if ok := helper.Contains(packageMonikers, item.Moniker); ok {
+				if ok := helper.Contains(p.Monikers, item.Moniker); ok {
 					yodaStatusMetrics.
 						With(prometheus.Labels{
 							common.ValidatorAddressLabel: item.ValidatorOperatorAddress,


### PR DESCRIPTION
## PR(Pull Request) Overview

A simple change to allow defining individual lists of monikers for each network.

If no `monikers` variable is defined, the content of the root `monikers` variable will be used.

This helps in situation were you need to track different monikers across different networks, without the need to define them all globally for all networks

#### Changes

- [ ] Major feature addition or modification
- [ ] Bug fix
- [x] Code improvement
- [ ] Documentation update

#### Description of Changes

This change allows to specify individual lists of monikers which should be tracked per configured chain. E.g.
```
monikers:
  - 'validator1'
  - 'validator2'


  - display_name: 'band'
    chain_id: 'laozi-mainnet'
    monikers:
      - 'validator3'  # <-- will only track 'validator3'
    tracking_addresses:
      - 'xyz'
    nodes:
      - ...


  - display_name: 'injective' # <-- will track 'validator1' and 'validator2'
    chain_id: injective-1
    tracking_addresses:
      - 'xyz'
    nodes:
      - ...
```

#### Testing Method

Just a simple execution to test if the overwrite works or not. I did not add any tests yet


