### PR TITLE
feat: Add support for using env vars in config

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -181,6 +181,25 @@ chains:
         grpc: 'grpc-axelar.endpoint.xyz:9090'
 ```
 
+## Example Using Environment Variables
+Environment variables can be used to inject values into the configuration file. 
+For this a simple template variable marked by `${}` (e.g. `${SUPER_SECRET_ENV_VAR}`) can be added to the config file.
+
+```yaml
+monikers: ['all']
+
+chains:
+  - display_name: 'cosmos'
+    chain_id: cosmoshub-4
+    tracking_addresses:
+      - 'cosmos1clpqr4nrk4khgkxj78fcwwh6dl3uw4ep4tgu9q'
+      - '${THIS_IS_ALSO_AN_ENV_VAR}'
+    nodes:
+      - rpc: 'https://rpc-cosmos.endpoint.xyz/${SUPER_SECRET_TOKEN}'
+        api: 'https://lcd-cosmos.endpoint.xyz/${ANOTHER_ENV_VAR}'
+        grpc: 'grpc-cosmos.endpoint.xyz:9090'
+```
+
 ## Example: Supporting Custom Chain
 
 For devents, testnets, localnet even if unsupported mainnets, Use `custom_chains.yaml` for CVMS


### PR DESCRIPTION
## PR(Pull Request) Overview

This change allows users to add tags to the configuration file which can be replaced via environment variables. 
This can be useful in cases were access tokens should be injected into the config, but should not be directly
stored in the config file.

#### Changes

- [ ] Major feature addition or modification
- [ ] Bug fix
- [x] Code improvement
- [ ] Documentation update

#### Description of Changes

This change invokes a search and replace routine before the loaded config is unmarshaled by the yaml parser. 
The function searches for all entries matching  the regex (`${...}`) and tries to load an environment variable 
of the same name. If nothing is found nothing will be replaced.


#### Testing Method

I added a small unit test to `config_test.go`

#### Additional Information

I was considering using the `text/template` package instead, but decided otherwise as I wanted to keep the 
functionality at a minimum and not add additional support for more templating.
