### PR TITLE
Remove theta-testnet-001 in support_chains.yaml

### DIFF
--- a/docker/cvms/support_chains.yaml
+++ b/docker/cvms/support_chains.yaml
@@ -1210,18 +1210,6 @@ test-core-2:
     - upgrade
     - uptime
     - voteindexer
-theta-testnet-001:
-  chain_name: cosmos
-  protocol_type: cosmos
-  mainnet: false
-  support_asset:
-    denom: uatom
-    decimal: 6
-  packages:
-    - block
-    - upgrade
-    - uptime
-    - voteindexer
 umee-1:
   chain_name: umee
   protocol_type: cosmos


### PR DESCRIPTION
## PR(Pull Request) Overview

Deleting chains that are no longer supported

#### Changes

- [x] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update

#### Description of Changes

Removed from support-chains.yml as it no longer supports theta-testnet-001.

#### Additional Information

This was officially announced on the Foundation's communication channels.
<img width="821" alt="스크린샷 2024-12-09 오후 12 03 47" src="https://github.com/user-attachments/assets/88fde847-c5b1-4fee-b388-97c1a2cb7243">
