### PR TITLE
add support for elys-mainnet network

### DIFF
--- a/docker/cvms/support_chains.yaml
+++ b/docker/cvms/support_chains.yaml
@@ -440,6 +440,18 @@ evmos_9001-2:
     - upgrade
     - uptime
     - voteindexer
+elys-1:
+  chain_name: elys
+  protocol_type: cosmos
+  mainnet: true
+  support_asset:
+    denom: uelys
+    decimal: 6
+  packages:
+    - block
+    - upgrade
+    - uptime
+    - voteindexer
 fetchhub-4:
   chain_name: fetchai
   protocol_type: cosmos


### PR DESCRIPTION
Update support_chains.yaml

## PR(Pull Request) Overview

Briefly describe the changes made in this PR.

#### Changes

- [ ] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update
- [ ✅ ] New chain addition

#### Related Issue

N/A

#### Description of Changes

New chain: elys-1 mainnet network is added

#### Testing Method

Tested locally by setting the `config.yaml` file:
```
cvms-indexer       | level="info" msg="supported packages for indexer application: [voteindexer veindexer]"
cvms-indexer       | level="info" msg="this is new chain id: elys-1" chain="elys" chain_id="elys-1" package="voteindexer"
cvms-indexer       | level="info" msg="loaded index pointer(last saved height): 41233" chain="elys" chain_id="elys-1" package="voteindexer"
cvms-indexer       | level="info" msg="initial vim length: 0 for elys-1 chain" chain="elys" chain_id="elys-1" package="voteindexer"
cvms-indexer       | level="info" msg="current height is 41233 and latest height is 41233 both of them are same, so it'll skip the logic" chain="elys" chain_id="elys-1" package="voteindexer"
cvms-indexer       | level="info" msg="updated index pointer to 41233 and sleep 5s sec..." chain="elys" chain_id="elys-1" package="voteindexer" catching_up="false"
cvms-exporter      | level="error" msg="current errors count: 21" chain="elys" chain_id="elys-1" package="uptime"
```
#### Additional Information

N/A