### PR TITLE
[Enhancement] Handle balance errors gracefully

### DIFF
--- a/internal/packages/utility/balance/errors/errors.go
+++ b/internal/packages/utility/balance/errors/errors.go
@@ -1,0 +1,10 @@
+package errors
+
+import (
+	"errors"
+)
+
+var (
+	// ErrBalanceNotFound is returned when the requested balance is not found.
+	ErrBalanceNotFound = errors.New("balance not found for denom")
+)

--- a/internal/packages/utility/balance/parser/parser.go
+++ b/internal/packages/utility/balance/parser/parser.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/cosmostation/cvms/internal/helper"
+	balanceErrors "github.com/cosmostation/cvms/internal/packages/utility/balance/errors"
 	"github.com/cosmostation/cvms/internal/packages/utility/balance/types"
 )
 
@@ -25,7 +26,7 @@ func CosmosBalanceParser(resp []byte, denom string) (float64, error) {
 	}
 
 	if stringBalance == "" {
-		return 0, fmt.Errorf("failed to get specific denom balnce")
+		return 0, balanceErrors.ErrBalanceNotFound
 	}
 
 	balance, err := strconv.ParseFloat(stringBalance, 64)

--- a/internal/packages/utility/balance/parser/parser_test.go
+++ b/internal/packages/utility/balance/parser/parser_test.go
@@ -1,0 +1,53 @@
+package parser_test
+
+import (
+	"testing"
+
+	balanceErrors "github.com/cosmostation/cvms/internal/packages/utility/balance/errors"
+	parser "github.com/cosmostation/cvms/internal/packages/utility/balance/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCosmosBalanceParsing(t *testing.T) {
+
+	resp := []byte(`{
+  "balances": [
+    {
+      "denom": "factory/neutronxyzasdf/Governance",
+      "amount": "123"
+    },
+    {
+      "denom": "ibc/bla",
+      "amount": "120"
+    },
+    {
+      "denom": "untrn",
+      "amount": "10000"
+    }
+  ],
+  "pagination": {
+    "next_key": null,
+    "total": "3"
+  }
+}`)
+
+	rep_no_balance := []byte(`{
+  "balances": [],
+  "pagination": {
+    "next_key": null,
+    "total": "0"
+  }
+}`)
+
+	balance_untrn, err := parser.CosmosBalanceParser(resp, "untrn")
+	assert.Nil(t, err)
+	balance_unknown, err := parser.CosmosBalanceParser(resp, "asdf")
+	assert.ErrorIs(t, balanceErrors.ErrBalanceNotFound, err)
+	balance_unknown_no_balance, err := parser.CosmosBalanceParser(rep_no_balance, "asdf")
+	assert.ErrorIs(t, balanceErrors.ErrBalanceNotFound, err)
+
+	assert.Equal(t, float64(10000), balance_untrn)
+	assert.Equal(t, float64(0), balance_unknown)
+	assert.Equal(t, float64(0), balance_unknown_no_balance)
+
+}


### PR DESCRIPTION

## PR(Pull Request) Overview

A small enhancement to handle empty balance responses in a graceful manner. This prevents errors in case the balance of an address is 0. This can happen if a validator address does not hold any tokens itself. In such a case it is assumed the balance of the address is 0

#### Changes

- [x] Code improvement


#### Description of Changes

To catch the exception/error a new error type `ErrBalanceNotFound` is created. This error will be used if the `StringBalance`
is empty. The higher level code will catch this specific error assume the balance as `0` and raise a warning instead. 

#### Testing Method

I added a unit test to test the behavior is as expected
