### PR TITLE
fix typo in parser.go

### DIFF
--- a/internal/packages/utility/balance/parser/parser.go
+++ b/internal/packages/utility/balance/parser/parser.go
@@ -25,7 +25,7 @@ func CosmosBalanceParser(resp []byte, denom string) (float64, error) {
 	}
 
 	if stringBalance == "" {
-		return 0, fmt.Errorf("failed to get specific denom balnce")
+		return 0, fmt.Errorf("failed to get specific denom balance")
 	}
 
 	balance, err := strconv.ParseFloat(stringBalance, 64)


### PR DESCRIPTION
fix typo in parse.go

```
'balnce' => 'balance'
```

## PR(Pull Request) Overview

Fix typo in `cvms/internal/packages/utility/balance/parser.go`

#### Changes

- [ ] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update
- [ ✅ ] Fix typo

#### Related Issue

N/A

#### Description of Changes

Fix typo in `cvms/internal/packages/utility/balance/parser.go`

```
'balnce' => 'balance'
```

#### Testing Method

Locally tested with `neutron` chain

```
cvms-exporter      | level="error" msg="api error: failed to get specific denom balnce" chain="neutron" chain_id="neutron-1" package="balance"
```
#### Additional Information

N/A