### PR TITLE
Implement babylon finality provider indexer package

### DIFF
--- a/docker/cvms/support_chains.yaml
+++ b/docker/cvms/support_chains.yaml
@@ -178,6 +178,7 @@ bbn-test-5:
     - uptime
     - voteindexer
     - babylon_checkpoint
+    - finality_provider_indexer
 bitcanna-1:
   chain_name: bitcanna
   protocol_type: cosmos

--- a/docker/grafana/provisioning/dashboards/dashboard.yaml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yaml
@@ -7,7 +7,7 @@ providers:
     folder: 'Validator Dashboards'
     type: file
     disableDeletion: false
-    editable: false
+    editable: true
     options:
       path: /etc/grafana/provisioning/dashboards/validator
 
@@ -16,6 +16,6 @@ providers:
     folder: 'Network Dashboards'
     type: file
     disableDeletion: false
-    editable: false
+    editable: true
     options:
       path: /etc/grafana/provisioning/dashboards/network

--- a/docker/postgres/schema/01-init-meta.sql
+++ b/docker/postgres/schema/01-init-meta.sql
@@ -43,3 +43,22 @@ CREATE TABLE
     )
 PARTITION BY
     LIST ("chain_info_id");
+
+
+-- "moniker": "Cosmostation"
+-- "addr": "bbn1x5wgh6vwye60wv3dtshs9dmqggwfx2ldy7agnk"
+-- "btc_pk": "894add70131a47375ce48ff2adc969721c13b600f8726ad21ee018b9b97f4db4"
+CREATE TABLE
+    IF NOT EXISTS "meta"."finality_provider_info" (
+        "id" BIGINT GENERATED ALWAYS AS IDENTITY,
+        "chain_info_id" INT NOT NULL,
+        "moniker" TEXT NOT NULL, 
+        "operator_address" TEXT NOT NULL,
+        "btc_pk" VARCHAR(64) NOT NULL,
+        CONSTRAINT fk_chain_info_id FOREIGN KEY (chain_info_id) REFERENCES meta.chain_info(id) ON DELETE CASCADE ON UPDATE CASCADE,
+        PRIMARY KEY ("id", "chain_info_id"),
+        CONSTRAINT uniq_btc_pk_by_chain UNIQUE (chain_info_id, btc_pk),
+        CONSTRAINT uniq_finality_operator_address_by_chain UNIQUE (chain_info_id, operator_address)
+    )
+PARTITION BY
+    LIST ("chain_info_id");

--- a/docker/postgres/schema/02-init-babylon_finality_provider.sql
+++ b/docker/postgres/schema/02-init-babylon_finality_provider.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "public"."babylon_finality_provider" (
+        "id" BIGINT GENERATED ALWAYS AS IDENTITY,
+        "chain_info_id" INT NOT NULL,
+        "height" BIGINT NOT NULL,
+        "finality_provider_pk_id" INT NOT NULL,
+        "status" SMALLINT NOT NULL, 
+        "timestamp" timestamptz NOT NULL,
+        PRIMARY KEY ("id", "chain_info_id"),
+        CONSTRAINT fk_chain_info_id FOREIGN KEY (chain_info_id) REFERENCES meta.chain_info (id) ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT fk_finality_provider_pk_id FOREIGN KEY (finality_provider_pk_id, chain_info_id) REFERENCES meta.finality_provider_info (id, chain_info_id),
+        CONSTRAINT uniq_babylon_finality_provider_by_height UNIQUE ("chain_info_id","height","finality_provider_pk_id")
+    )
+PARTITION BY
+    LIST ("chain_info_id");
+
+CREATE INDEX IF NOT EXISTS babylon_finality_provider_idx_01 ON public.babylon_finality_provider (height);
+CREATE INDEX IF NOT EXISTS babylon_finality_provider_idx_02 ON public.babylon_finality_provider (finality_provider_pk_id, height);
+CREATE INDEX IF NOT EXISTS babylon_finality_provider_idx_03 ON public.babylon_finality_provider USING btree (chain_info_id, finality_provider_pk_id, height asc);

--- a/internal/common/api/api_test.go
+++ b/internal/common/api/api_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/cosmostation/cvms/internal/common"
+	"github.com/cosmostation/cvms/internal/helper/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+var p = common.Packager{Logger: logger.GetTestLogger()}
+
+func TestCheckGetBlockResultAndExtractFpVoting(t *testing.T) {
+	commonApp := common.NewCommonApp(p)
+	commonApp.SetRPCEndPoint("https://rpc-office.cosmostation.io/babylon-testnet")
+
+	txsEvents, _, err := GetBlockResults(commonApp.CommonClient, 92664)
+	assert.NoError(t, err)
+
+	const msg = "/babylon.finality.v1.MsgAddFinalitySig"
+	for _, e := range txsEvents {
+		for _, a := range e.Attributes {
+			if a.Value == msg {
+				t.Log(a)
+				t.Log(e)
+			}
+		}
+	}
+
+}

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -228,3 +228,13 @@ func GetStakingValidators(client common.CommonClient, chainName string, newStaki
 	}
 	return nil
 }
+
+func MakeFinalityProviderInfoList(
+	app common.CommonApp,
+	chainID string, chainInfoID int64,
+	chainName string, isConsumer bool,
+	newValidatorAddressMap map[string]bool,
+	height ...int64,
+) ([]indexermodel.FinalityProviderInfo, error) {
+	return nil, nil
+}

--- a/internal/common/indexer/model/meta.go
+++ b/internal/common/indexer/model/meta.go
@@ -6,6 +6,25 @@ import (
 	"github.com/uptrace/bun"
 )
 
+type FinalityProviderInfo struct {
+	bun.BaseModel   `bun:"table:meta.finality_provider_info"`
+	ID              int64  `bun:"id,pk,autoincrement"`
+	ChainInfoID     int64  `bun:"chain_info_id,pk,notnull"`
+	Moniker         string `bun:"moniker"`
+	BTCPKs          string `bun:"btc_pk"`
+	OperatorAddress string `bun:"operator_address"`
+}
+
+func (vi FinalityProviderInfo) String() string {
+	return fmt.Sprintf("FinalityProviderInfo<%d %d %s %s %s>",
+		vi.ID,
+		vi.ChainInfoID,
+		vi.BTCPKs,
+		vi.OperatorAddress,
+		vi.Moniker,
+	)
+}
+
 type ValidatorInfo struct {
 	bun.BaseModel `bun:"table:meta.validator_info"`
 

--- a/internal/common/indexer/repository/finality_provider_info.go
+++ b/internal/common/indexer/repository/finality_provider_info.go
@@ -1,0 +1,94 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosmostation/cvms/internal/common/indexer/model"
+
+	"github.com/cosmostation/cvms/internal/helper"
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+const finalityProviderInfoTableName = "finality_provider_info"
+
+func (repo *MetaRepository) CreateFinalityProviderInfoPartitionTableByChainID(chainID string) error {
+	ctx := context.Background()
+	defer ctx.Done()
+
+	ci := &model.ChainInfo{}
+	err := repo.
+		NewSelect().
+		Model(ci).
+		Column("id").
+		Where("chain_id = ?", chainID).
+		Scan(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to select chain_info id by chain_id")
+	}
+
+	tableNameWithSuffix := fmt.Sprintf("meta.%s_%s", finalityProviderInfoTableName, helper.ParseToSchemaName(chainID))
+	query := fmt.Sprintf(
+		`CREATE TABLE IF NOT EXISTS %s PARTITION OF "meta"."%s" FOR VALUES IN ('%d');`,
+		tableNameWithSuffix, finalityProviderInfoTableName, ci.ID,
+	)
+
+	_, err = repo.NewRaw(query).Exec(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to create a new partition table")
+	}
+
+	return nil
+}
+
+func (repo *MetaRepository) GetFinalityProviderInfoListByChainInfoID(chainInfoID int64) ([]model.FinalityProviderInfo, error) {
+	ctx := context.Background()
+	defer ctx.Done()
+
+	FinalityProviderInfoList := make([]model.FinalityProviderInfo, 0)
+	err := repo.
+		NewSelect().
+		Model(&FinalityProviderInfoList).
+		Where("chain_info_id = ?", chainInfoID).
+		Scan(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query validator_info list by chain_info_id")
+	}
+
+	return FinalityProviderInfoList, nil
+}
+
+func (repo *MetaRepository) InsertFinalityProviderInfoList(fpInfoList []model.FinalityProviderInfo) error {
+	ctx := context.Background()
+	defer ctx.Done()
+
+	_, err := repo.NewInsert().
+		Model(&fpInfoList).
+		ExcludeColumn("id").
+		Exec(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert validator info list")
+	}
+
+	return nil
+}
+
+func (repo *MetaRepository) GetFinalityProviderInfoListByMonikers(chainInfoID int64, monikers []string) ([]model.FinalityProviderInfo, error) {
+	ctx := context.Background()
+	defer ctx.Done()
+
+	FinalityProviderInfoList := make([]model.FinalityProviderInfo, 0)
+	err := repo.
+		NewSelect().
+		Model(&FinalityProviderInfoList).
+		ColumnExpr("*").
+		Where("chain_info_id = ?", chainInfoID).
+		Where("moniker in (?)", bun.In(monikers)).
+		Scan(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query validator_info list by chain_info_id")
+	}
+
+	return FinalityProviderInfoList, nil
+}

--- a/internal/common/indexer/repository/interfaces.go
+++ b/internal/common/indexer/repository/interfaces.go
@@ -7,6 +7,7 @@ type IMetaRepository interface {
 	IChainInfoRepository
 	IIndexPointerRepository
 	IValidatorInfoRepository
+	IFinalityProviderInfoRepository
 
 	// common sql interface for partition tables
 	CreatePartitionTable(IndexName, chainID string) error
@@ -32,4 +33,12 @@ type IValidatorInfoRepository interface {
 	GetValidatorInfoListByChainInfoID(chainInfoID int64) (validatorInfoList []model.ValidatorInfo, err error)
 	InsertValidatorInfoList(validatorInfoList []model.ValidatorInfo) error
 	GetValidatorInfoListByMonikers(chainInfoID int64, monikers []string) ([]model.ValidatorInfo, error)
+}
+
+// interface for about meta.finality_provider table
+type IFinalityProviderInfoRepository interface {
+	CreateFinalityProviderInfoPartitionTableByChainID(chainID string) error
+	GetFinalityProviderInfoListByChainInfoID(chainInfoID int64) (fpInfoList []model.FinalityProviderInfo, err error)
+	InsertFinalityProviderInfoList([]model.FinalityProviderInfo) error
+	GetFinalityProviderInfoListByMonikers(chainInfoID int64, monikers []string) ([]model.FinalityProviderInfo, error)
 }

--- a/internal/common/packager.go
+++ b/internal/common/packager.go
@@ -14,6 +14,7 @@ var (
 		"voteindexer",
 		"veindexer",
 		"babylon_checkpoint",
+		"finality_provider_indexer",
 	}
 
 	ExporterPackages = []string{

--- a/internal/common/types/cosmos.go
+++ b/internal/common/types/cosmos.go
@@ -266,3 +266,41 @@ type CosmosUpgradeResponse struct {
 		UpgradedClientState string `json:"upgraded_client_state"`
 	} `json:"plan"`
 }
+
+var CosmosBlockResultsQueryPath = func(height int64) string {
+	return fmt.Sprintf("/block_results?height=%d", height)
+}
+
+type CosmosBlockResultResponse struct {
+	JsonRPC string `json:"jsonrpc" validate:"required"`
+	ID      int    `json:"id" validate:"required"`
+	Result  struct {
+		Height     string     `json:"height"`
+		TxsResults []TxResult `json:"txs_results"`
+		// case1)
+		// https://github.com/cometbft/cometbft/blob/v0.37.0/rpc/core/types/responses.go#L54
+		BeginBlockEvents []BlockEvent `json:"begin_block_events"`
+		EndBlockEvents   []BlockEvent `json:"end_block_events"`
+		// case2)
+		// https://github.com/cometbft/cometbft/blob/v0.38.0/rpc/core/types/responses.go#L54
+		FinalizeBlockEvents []BlockEvent `json:"finalize_block_events"`
+		//
+		ValidatorUpdate       interface{}    `json:"-"`
+		ConsensusParamUpdates map[string]any `json:"-"`
+	} `json:"result" validate:"required"`
+}
+type TxResult struct {
+	Code   int64        `json:"code"`
+	Events []BlockEvent `json:"events"`
+}
+
+type BlockEvent struct {
+	TypeName   string      `json:"type"`
+	Attributes []Attribute `json:"attributes"`
+}
+
+type Attribute struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Index bool   `json:"index"`
+}

--- a/internal/packages/consensus/babylon-checkpoint/indexer/indexer_test.go
+++ b/internal/packages/consensus/babylon-checkpoint/indexer/indexer_test.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -176,4 +177,27 @@ func TestSyncMachnismForBLSsigning(t *testing.T) {
 	} else {
 		t.Logf("validator address is correct: %X", hexAddress)
 	}
+}
+func TestMakeBLSAddressFromCometBFTAddress(t *testing.T) {
+	hexAddress := "96FD92D649AE03B2F5B83098D3E47669F99200B5"
+
+	// Decode the hex string to bytes
+	bytes, err := hex.DecodeString(hexAddress)
+	if err != nil {
+		t.Errorf("failed to decode hex string: %v", err)
+	}
+
+	// Encode the bytes to a base64 string
+	base64Address := base64.StdEncoding.EncodeToString(bytes)
+
+	// Expected base64-encoded string
+	expectedAddress := "lv2S1kmuA7L1uDCY0+R2afmSALU="
+
+	// Validate the result
+	if base64Address != expectedAddress {
+		t.Errorf("base64 address does not match: got %s, expected %s", base64Address, expectedAddress)
+	} else {
+		t.Logf("base64 address is correct: %s", base64Address)
+	}
+
 }

--- a/internal/packages/duty/finality-provider-indexer/indexer/api.go
+++ b/internal/packages/duty/finality-provider-indexer/indexer/api.go
@@ -1,0 +1,94 @@
+package indexer
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cosmostation/cvms/internal/common"
+	indexmodel "github.com/cosmostation/cvms/internal/common/indexer/model"
+	"github.com/pkg/errors"
+)
+
+func GetFinalityProviderByHeight(c common.CommonClient, height int64) ([]FinalityProvider, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
+	defer cancel()
+
+	requester := c.APIClient.R().SetContext(ctx)
+	resp, err := requester.Get(BabylonFinalityProvidersQueryPath(height))
+	if err != nil {
+		return nil, errors.Errorf("rpc call is failed from %s: %s", resp.Request.URL, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, errors.Errorf("stanage status code from %s: [%d]", resp.Request.URL, resp.StatusCode())
+	}
+
+	fps, err := ParseFinalityProviders(resp.Body())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return fps.FinalityProviders, nil
+}
+
+func GetFinalityVotesByHeight(c common.CommonClient, height int64) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
+	defer cancel()
+
+	requester := c.APIClient.R().SetContext(ctx)
+	resp, err := requester.Get(BabylonFinalityVotesQueryPath(height))
+	if err != nil {
+		return nil, errors.Errorf("rpc call is failed from %s: %s", resp.Request.URL, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, errors.Errorf("stanage status code from %s: [%d]", resp.Request.URL, resp.StatusCode())
+	}
+
+	votes, err := ParseFinalityProviderVotings(resp.Body())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return votes.BTCPKs, nil
+}
+
+func GetFinalityProvidersInfo(c common.CommonClient, newFinalityProviderMap map[string]bool, chainInfoID int64) ([]indexmodel.FinalityProviderInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
+	defer cancel()
+
+	requester := c.APIClient.R().SetContext(ctx)
+
+	fpInfoList := make([]indexmodel.FinalityProviderInfo, 0)
+	maxCnt := 10
+	key := ""
+	for cnt := 0; cnt <= maxCnt; cnt++ {
+		resp, err := requester.Get(BabylonFinalityProviderInfosQueryPath(key))
+		if err != nil {
+			return nil, errors.Errorf("rpc call is failed from %s: %s", resp.Request.URL, err)
+		}
+		if resp.StatusCode() != http.StatusOK {
+			return nil, errors.Errorf("stanage status code from %s: [%d]", resp.Request.URL, resp.StatusCode())
+		}
+		fpInfos, err := ParseFinalityProviderInfos(resp.Body())
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		for _, fp := range fpInfos.FinalityProviders {
+			fpInfoList = append(fpInfoList, indexmodel.FinalityProviderInfo{
+				ChainInfoID:     chainInfoID,
+				Moniker:         fp.Description.Moniker,
+				BTCPKs:          fp.BTCPK,
+				OperatorAddress: fp.Address,
+			})
+		}
+
+		if fpInfos.Pagination.NextKey != "" {
+			key = fpInfos.Pagination.NextKey
+		} else {
+			// got all finality provider infos
+			break
+		}
+	}
+
+	return fpInfoList, nil
+}

--- a/internal/packages/duty/finality-provider-indexer/indexer/babylon.go
+++ b/internal/packages/duty/finality-provider-indexer/indexer/babylon.go
@@ -1,0 +1,119 @@
+package indexer
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Define the structures for the JSON data
+type SigningInfo struct {
+	FPBTCPkHex          string `json:"fp_btc_pk_hex"`
+	StartHeight         string `json:"start_height"`
+	MissedBlocksCounter string `json:"missed_blocks_counter"`
+	JailedUntil         string `json:"jailed_until"`
+}
+
+type Pagination struct {
+	NextKey string `json:"next_key"`
+	Total   string `json:"total"`
+}
+
+type SigningInfoResponse struct {
+	SigningInfos []SigningInfo `json:"signing_infos"`
+	Pagination   Pagination    `json:"pagination"`
+}
+
+func ParserFinalityProviderSigningInfos(resp []byte) (SigningInfoResponse, error) {
+	var result SigningInfoResponse
+	err := json.Unmarshal(resp, &result)
+	if err != nil {
+		fmt.Println("Error parsing JSON:", err)
+		return SigningInfoResponse{}, nil
+	}
+
+	return result, nil
+}
+
+var BabylonFinalityProvidersQueryPath = func(height int64) string {
+	return fmt.Sprintf("/babylon/finality/v1/finality_providers/%d", height)
+}
+
+type FinalityProvider struct {
+	BtcPkHex             string `json:"btc_pk_hex"`
+	Height               string `json:"height"`
+	VotingPower          string `json:"voting_power"`
+	SlashedBabylonHeight string `json:"slashed_babylon_height"`
+	SlashedBtcHeight     int    `json:"slashed_btc_height"`
+	Jailed               bool   `json:"jailed"`
+	HighestVotedHeight   int    `json:"highest_voted_height"`
+}
+
+type FinalityProvidersResponse struct {
+	FinalityProviders []FinalityProvider `json:"finality_providers"`
+	Pagination        Pagination         `json:"pagination"`
+}
+
+func ParseFinalityProviders(resp []byte) (FinalityProvidersResponse, error) {
+	var result FinalityProvidersResponse
+	err := json.Unmarshal(resp, &result)
+	if err != nil {
+		fmt.Println("Error parsing JSON:", err)
+		return FinalityProvidersResponse{}, nil
+	}
+
+	return result, nil
+}
+
+var BabylonFinalityVotesQueryPath = func(height int64) string {
+	return fmt.Sprintf("/babylon/finality/v1/votes/%d", height)
+}
+
+type FinalityVotesResponse struct {
+	BTCPKs []string `json:"btc_pks"`
+}
+
+func ParseFinalityProviderVotings(resp []byte) (FinalityVotesResponse, error) {
+	var result FinalityVotesResponse
+	err := json.Unmarshal(resp, &result)
+	if err != nil {
+		fmt.Println("Error parsing JSON:", err)
+		return FinalityVotesResponse{}, nil
+	}
+
+	return result, nil
+}
+
+var BabylonFinalityProviderInfosQueryPath = func(key string) string {
+	return fmt.Sprintf("/babylon/btcstaking/v1/finality_providers?pagination.key=%s", key)
+}
+
+type FinalityProviderInfosResponse struct {
+	FinalityProviders []FinalityProviderInfo `json:"finality_providers"`
+	Pagination        Pagination             `json:"pagination"`
+}
+
+type FinalityProviderInfo struct {
+	Description struct {
+		Moniker string `json:"moniker"`
+	} `json:"description"`
+	Address string `json:"addr"`
+	BTCPK   string `json:"btc_pk"`
+}
+
+func ParseFinalityProviderInfos(resp []byte) (FinalityProviderInfosResponse, error) {
+	var result FinalityProviderInfosResponse
+	err := json.Unmarshal(resp, &result)
+	if err != nil {
+		fmt.Println("Error parsing JSON:", err)
+		return FinalityProviderInfosResponse{}, nil
+	}
+
+	return result, nil
+}
+
+type fpVoteMap map[string]int64
+
+type FinalityVoteSummary struct {
+	BlockHeight           int64
+	FinalityProviderVotes fpVoteMap
+}

--- a/internal/packages/duty/finality-provider-indexer/indexer/batch_sync.go
+++ b/internal/packages/duty/finality-provider-indexer/indexer/batch_sync.go
@@ -1,0 +1,257 @@
+package indexer
+
+import (
+	"sync"
+	"time"
+
+	indexertypes "github.com/cosmostation/cvms/internal/common/indexer/types"
+	"github.com/cosmostation/cvms/internal/helper"
+	"github.com/cosmostation/cvms/internal/packages/duty/finality-provider-indexer/model"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// NOTE: in this package, the missed height means fp didn't broadcast the finality sig tx in height+1 block
+// for example, I didn't broadcast the tx at 100 block, that will make missed block for 99 height.
+func (idx *FinalityProviderIndexer) batchSync(lastIndexPointerHeight, newIndexPointerHeight int64) (
+	/* new index pointer */ int64,
+	/* error */ error,
+) {
+	if lastIndexPointerHeight >= idx.Lh.LatestHeight {
+		idx.Infof("current height is %d and latest height is %d both of them are same, so it'll skip the logic", lastIndexPointerHeight, idx.Lh.LatestHeight)
+		return lastIndexPointerHeight, nil
+	}
+
+	// set starntHeight and endHeight for batch sync
+	// NOTE: end height will use latest height -1 for waiting latest vote status
+	startHeight := newIndexPointerHeight
+	endHeight := (idx.Lh.LatestHeight - 1)
+
+	// set limit at end-height in this batch sync logic
+	if (idx.Lh.LatestHeight - newIndexPointerHeight) > indexertypes.BatchSyncLimit {
+		endHeight = newIndexPointerHeight + indexertypes.BatchSyncLimit
+		idx.Debugf("by batch sync limit, end height will change to %d", endHeight)
+	}
+
+	// init channel and waitgroup for go-routine
+	ch := make(chan helper.Result)
+	var wg sync.WaitGroup
+
+	// init summary list
+	FinalityVoteSummaryList := make(map[int64]FinalityVoteSummary, 0)
+
+	// start to call block data
+	for height := startHeight; height <= endHeight; height++ {
+		wg.Add(1)
+		missedHeight := height
+
+		go func(ch chan helper.Result) {
+			defer helper.HandleOutOfNilResponse(idx.Entry)
+			defer wg.Done()
+
+			// get current block for collecting last commit signatures
+			fps, err := GetFinalityProviderByHeight(idx.CommonClient, missedHeight)
+			if err != nil {
+				idx.Errorf("failed to call at %d height data, %s", missedHeight, err)
+				ch <- helper.Result{Item: nil, Success: false}
+				return
+			}
+
+			// make a map by fp votes with default value(false)
+			fpVoteMap := make(fpVoteMap, len(fps))
+			for _, fp := range fps {
+				fpVoteMap[fp.BtcPkHex] = 0 // missed
+			}
+
+			// get previous tendermint validators for collecting  validators' hex address
+			btcPKs, err := GetFinalityVotesByHeight(idx.CommonClient, missedHeight)
+			if err != nil {
+				idx.Errorf("failed to call at %d height data, %s", height, err)
+				ch <- helper.Result{Item: nil, Success: false}
+				return
+			}
+
+			// if empty response, the height is not updated yet wait for while
+			if len(btcPKs) == 0 {
+				idx.Warnf("finality provider vote status was not updated yet for %d height", missedHeight)
+				ch <- helper.Result{Item: nil, Success: false}
+			}
+
+			// if the pk is existed in the votings, update the value for fp
+			for _, pk := range btcPKs {
+				fpVoteMap[pk] = 1 // voted
+			}
+
+			idx.Infof("in %d+1 block, total fp: %d but voted only %d", missedHeight, len(fps), len(btcPKs))
+
+			ch <- helper.Result{
+				Item: FinalityVoteSummary{
+					BlockHeight:           height,
+					FinalityProviderVotes: fpVoteMap,
+				},
+				Success: true,
+			}
+		}(ch)
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// close channel
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	// collect summary data into summary list
+	errorCount := 0
+	for r := range ch {
+		if r.Success {
+			item := r.Item.(FinalityVoteSummary)
+			FinalityVoteSummaryList[item.BlockHeight] = item
+			continue
+		}
+		errorCount++
+	}
+
+	// check error count
+	if errorCount > 0 {
+		return lastIndexPointerHeight, errors.Errorf("failed to collect batch block data, total errors: %d", errorCount)
+	}
+
+	// if there are new btc pk in current block, collect their validator hex address to save in database
+	isNewFinalityProvider := false
+	newFinalityProviderMap := make(map[string]bool, 0)
+	for _, item := range FinalityVoteSummaryList {
+		for pk := range item.FinalityProviderVotes {
+			_, exist := idx.Vim[pk]
+			if !exist {
+				// idx.Debugf("the miss finality provider %s isn't in current validator info table, it will be gonna added into the table", pk)
+				newFinalityProviderMap[pk] = true
+				isNewFinalityProvider = true
+			}
+		}
+	}
+
+	// this logic will be progressed only when there are new tendermint validators in this block
+	if isNewFinalityProvider {
+		newfpInfoList, err := GetFinalityProvidersInfo(idx.CommonClient, newFinalityProviderMap, idx.ChainInfoID)
+		if err != nil {
+			errors.Wrap(err, "failed to make validator info list")
+		}
+
+		idx.Debugf("insert new finality providers: %d", len(newfpInfoList))
+
+		// insert new validators' proposer address into the validator info table
+		err = idx.repo.InsertFinalityProviderInfoList(newfpInfoList)
+		if err != nil {
+			// NOTE: fetch again validator_info list, actually already inserted the list by other indexer service
+			idx.FetchValidatorInfoList()
+			return lastIndexPointerHeight, errors.WithStack(err)
+		}
+
+		// get already saved tendermint validator list for mapping validators ids
+		fpInfoList, err := idx.repo.GetFinalityProviderInfoListByChainInfoID(idx.ChainInfoID)
+		if err != nil {
+			return lastIndexPointerHeight, errors.Wrap(err, "failed to get new validator info list after inserting new hex address list")
+
+		}
+
+		for _, fp := range fpInfoList {
+			idx.Vim[fp.BTCPKs] = int64(fp.ID)
+		}
+
+		idx.Debugf("changed vim length: %d", len(idx.Vim))
+	}
+
+	fpvList := make([]model.BabylonFinalityProviderVote, 0)
+	for height := startHeight; height <= endHeight; height++ {
+		if height != FinalityVoteSummaryList[height].BlockHeight {
+			idx.Panicln("unexpected")
+		}
+
+		tempValidatorVoteList, err := makeBabylonFinalityProviderVoteList(
+			idx.Entry,
+			idx.ChainInfoID,
+			idx.Vim,
+			FinalityVoteSummaryList[height].BlockHeight,
+			FinalityVoteSummaryList[height].FinalityProviderVotes,
+		)
+		if err != nil {
+			return lastIndexPointerHeight, errors.Wrapf(err, "failed to make temp validator miss list at %d height", height)
+		}
+
+		fpvList = append(fpvList, tempValidatorVoteList...)
+	}
+
+	// NOTE: if solo validator mode, we don't need to insert all validotors vote status.
+	// so, filter statues by moniker
+	if len(idx.Monikers) > 0 {
+		// if not init monikerIDMap
+		if len(idx.MonikerIDMap) != len(idx.Monikers) {
+			// init monikerIDMap
+			validatorInfoList, err := idx.repo.GetFinalityProviderInfoListByMonikers(idx.ChainInfoID, idx.Monikers)
+			if err != nil {
+				return lastIndexPointerHeight, errors.Wrap(err, "failed to get validator_info list by monikers")
+			}
+			monikerIDMap := make(indexertypes.MonikerIDMap)
+			for _, vi := range validatorInfoList {
+				monikerIDMap[vi.ID] = true
+			}
+			// restore monikerIDMap in voteindexer struct, for reusing
+			idx.MonikerIDMap = monikerIDMap
+		}
+
+		// override for solo validator
+		fpvList = filterValidatorVoteListByMonikers(idx.MonikerIDMap, fpvList)
+	}
+
+	// need to save list and new pointer
+	err := idx.repo.InsertFinalityProviderVoteList(idx.ChainInfoID, FinalityVoteSummaryList[endHeight].BlockHeight, fpvList)
+	if err != nil {
+		return lastIndexPointerHeight, errors.Wrapf(err, "failed to insert from %d to %d height", startHeight, endHeight)
+	}
+
+	// update metrics
+	// idx.updatePrometheusMetrics(blockSummaryList[endHeight].BlockHeight, blockSummaryList[endHeight].BlockTimeStamp)
+	return FinalityVoteSummaryList[endHeight].BlockHeight, nil
+}
+
+func makeBabylonFinalityProviderVoteList(
+	l *logrus.Entry,
+	chainInfoID int64,
+	validatorIDMap indexertypes.ValidatorIDMap,
+	missedBlockHeight int64,
+	fpVotes fpVoteMap,
+) ([]model.BabylonFinalityProviderVote, error) {
+	bfpVoteList := make([]model.BabylonFinalityProviderVote, 0)
+	for btcPK, status := range fpVotes {
+		fpPKID, exist := validatorIDMap[btcPK]
+		if !exist {
+			return nil, errors.New("failed to find missed validators hex address id in validator id maps")
+		}
+		if status == 0 {
+			l.Debugf("found missed finality provider idx: %d, address: %s in this block height: %d", validatorIDMap[btcPK], btcPK, missedBlockHeight)
+		}
+		bfpVoteList = append(bfpVoteList, model.BabylonFinalityProviderVote{
+			ChainInfoID:          chainInfoID,
+			Height:               missedBlockHeight,
+			FinalityProviderPKID: fpPKID,
+			Status:               int64(status),
+			CreatedTime:          time.Now(),
+		})
+	}
+	return bfpVoteList, nil
+}
+
+func filterValidatorVoteListByMonikers(monikerIDMap indexertypes.MonikerIDMap, bfpvList []model.BabylonFinalityProviderVote) []model.BabylonFinalityProviderVote {
+	// already inited monikerIDMap just filter validator vote by moniker id maps
+	newFinalityProviderVoteList := make([]model.BabylonFinalityProviderVote, 0)
+	for _, bfpv := range bfpvList {
+		// // only append validaor vote in package monikers
+		_, exist := monikerIDMap[bfpv.FinalityProviderPKID]
+		if exist {
+			newFinalityProviderVoteList = append(newFinalityProviderVoteList, bfpv)
+		}
+	}
+	return newFinalityProviderVoteList
+}

--- a/internal/packages/duty/finality-provider-indexer/indexer/indexer.go
+++ b/internal/packages/duty/finality-provider-indexer/indexer/indexer.go
@@ -1,0 +1,209 @@
+package indexer
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/cosmostation/cvms/internal/helper"
+	"github.com/cosmostation/cvms/internal/helper/db"
+	"github.com/cosmostation/cvms/internal/helper/healthcheck"
+
+	"github.com/cosmostation/cvms/internal/common"
+	indexertypes "github.com/cosmostation/cvms/internal/common/indexer/types"
+	"github.com/cosmostation/cvms/internal/packages/duty/finality-provider-indexer/repository"
+)
+
+var (
+	supportedProtocolTypes = []string{"cosmos"}
+	subsystem              = "babylon_finality_provider_vote"
+)
+
+type FinalityProviderIndexer struct {
+	*common.Indexer
+	repo repository.FinalityProviderIndexerRepository
+}
+
+// Compile-time Assertion
+var _ common.IIndexer = (*FinalityProviderIndexer)(nil)
+
+func NewFinalityProviderIndexer(p common.Packager) (*FinalityProviderIndexer, error) {
+	status := helper.GetOnChainStatus(p.RPCs, p.ProtocolType)
+	if status.ChainID == "" {
+		return nil, errors.Errorf("failed to create new voteindexer by failing getting onchain status through %v", p.RPCs)
+	}
+	indexer := common.NewIndexer(p, p.Package, status.ChainID)
+	repo := repository.NewRepository(*p.IndexerDB, indexertypes.SQLQueryMaxDuration)
+	indexer.Lh = indexertypes.LatestHeightCache{LatestHeight: status.BlockHeight}
+	return &FinalityProviderIndexer{indexer, repo}, nil
+}
+
+func (idx *FinalityProviderIndexer) Start() error {
+	if ok := helper.Contains(supportedProtocolTypes, idx.ProtocolType); ok {
+		err := idx.InitChainInfoID()
+		if err != nil {
+			return errors.Wrap(err, "failed to init chain_info_id")
+		}
+
+		alreadyInit, err := idx.repo.CheckIndexpoinerAlreadyInitialized(repository.IndexName, idx.ChainInfoID)
+		if err != nil {
+			return errors.Wrap(err, "failed to check init tables")
+		}
+		if !alreadyInit {
+			idx.Warnln("it's not initialized in the database, so that voteindexer will init for this package")
+			idx.repo.InitPartitionTablesByChainInfoID(repository.IndexName, idx.ChainID, idx.Lh.LatestHeight)
+			idx.repo.CreateFinalityProviderInfoPartitionTableByChainID(idx.ChainID)
+		}
+
+		// get last index pointer, index pointer is always initalize if not exist
+		initIndexPointer, err := idx.repo.GetLastIndexPointerByIndexTableName(repository.IndexName, idx.ChainInfoID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get last index pointer")
+		}
+
+		err = idx.FetchValidatorInfoList()
+		if err != nil {
+			return errors.Wrap(err, "failed to fetch validator_info list")
+		}
+
+		idx.Infof("loaded index pointer(last saved height): %d", initIndexPointer.Pointer)
+		idx.Infof("initial vim length: %d for %s chain", len(idx.Vim), idx.ChainID)
+
+		// init indexer metrics
+		idx.initLabelsAndMetrics()
+		// go fetch new height in loop, it must be after init metrics
+		go idx.FetchLatestHeight()
+		// loop
+		go idx.Loop(initIndexPointer.Pointer)
+		// loop update recent miss counter metrics
+		// go func() {
+		// 	for {
+		// 		idx.Infoln("update recent miss counter metrics and sleep 5s sec...")
+		// 		idx.updateRecentMissCounterMetric()
+		// 		time.Sleep(time.Second * 5)
+		// 	}
+		// }()
+		// loop partion table time retention by env parameter
+		go func() {
+			if idx.RetentionPeriod == db.PersistenceMode {
+				idx.Infoln("skipped the postgres time retention")
+				return
+			}
+			for {
+				idx.Infof("for time retention, delete old records over %s and sleep %s", idx.RetentionPeriod, indexertypes.RetentionQuerySleepDuration)
+				idx.repo.DeleteOldFinalityProviderVoteList(idx.ChainID, idx.RetentionPeriod)
+				time.Sleep(indexertypes.RetentionQuerySleepDuration)
+			}
+		}()
+		return nil
+	}
+
+	return nil
+}
+
+func (idx *FinalityProviderIndexer) Loop(indexPoint int64) {
+	isUnhealth := false
+	for {
+		// node health check
+		if isUnhealth {
+			healthAPIs := healthcheck.FilterHealthEndpoints(idx.APIs, idx.ProtocolType)
+			for _, api := range healthAPIs {
+				idx.SetAPIEndPoint(api)
+				idx.Warnf("API endpoint will be changed with health endpoint for this package: %s", api)
+				isUnhealth = false
+				break
+			}
+
+			healthRPCs := healthcheck.FilterHealthRPCEndpoints(idx.RPCs, idx.ProtocolType)
+			for _, rpc := range healthRPCs {
+				idx.SetRPCEndPoint(rpc)
+				idx.Warnf("RPC endpoint will be changed with health endpoint for this package: %s", rpc)
+				isUnhealth = false
+				break
+			}
+
+			if len(healthAPIs) == 0 || len(healthRPCs) == 0 {
+				isUnhealth = true
+				idx.Errorln("failed to get any health endpoints from healthcheck filter, retry sleep 10s")
+				time.Sleep(indexertypes.UnHealthSleep)
+				continue
+			}
+		}
+
+		// set new index point height
+		newIndexPointerHeight := indexPoint + 1
+
+		// trying to sync with new index pointer height
+		newIndexPointer, err := idx.batchSync(indexPoint, newIndexPointerHeight)
+		if err != nil {
+			common.Health.With(idx.RootLabels).Set(0)
+			common.Ops.With(idx.RootLabels).Inc()
+			isUnhealth = true
+			idx.Errorf("failed to sync validators vote status in %d height: %s\nit will be retried after sleep %s...", indexPoint, err, indexertypes.AfterFailedFetchSleepDuration.String())
+			time.Sleep(indexertypes.AfterFailedRetryTimeout)
+			continue
+		}
+
+		// update index point
+		indexPoint = newIndexPointer
+
+		// update health and ops
+		common.Health.With(idx.RootLabels).Set(1)
+		common.Ops.With(idx.RootLabels).Inc()
+
+		// logging & sleep
+		if idx.Lh.LatestHeight > indexPoint {
+			// when node catching_up is true, sleep 100 milli sec
+			idx.WithField("catching_up", true).
+				Infof("latest height is %d but updated index pointer is %d ... remaining %d blocks", idx.Lh.LatestHeight, indexPoint, (idx.Lh.LatestHeight - indexPoint))
+			time.Sleep(indexertypes.CatchingUpSleepDuration)
+		} else {
+			// when node already catched up, sleep 5 sec
+			idx.WithField("catching_up", false).
+				Infof("updated index pointer to %d and sleep %s sec...", indexPoint, indexertypes.DefaultSleepDuration.String())
+			time.Sleep(indexertypes.DefaultSleepDuration)
+		}
+	}
+}
+
+// TODO: move into metarepo
+// insert chain-info into chain_info table
+func (idx *FinalityProviderIndexer) InitChainInfoID() error {
+	isNewChain := false
+	var chainInfoID int64
+	chainInfoID, err := idx.repo.SelectChainInfoIDByChainID(idx.ChainID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			idx.Infof("this is new chain id: %s", idx.ChainID)
+			isNewChain = true
+		} else {
+			return errors.Wrap(err, "failed to select chain_info_id by chain-id")
+		}
+	}
+
+	if isNewChain {
+		chainInfoID, err = idx.repo.InsertChainInfo(idx.ChainName, idx.ChainID, idx.Mainnet)
+		if err != nil {
+			return errors.Wrap(err, "failed to insert new chain_info_id by chain-id")
+		}
+	}
+
+	idx.ChainInfoID = chainInfoID
+	return nil
+}
+
+// NOTE: in finality provider, validator info means fp info
+func (idx *FinalityProviderIndexer) FetchValidatorInfoList() error {
+	// get already saved validator-set list for mapping validators ids
+	fpInfoList, err := idx.repo.GetFinalityProviderInfoListByChainInfoID(idx.ChainInfoID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get validator info list")
+	}
+
+	for _, fp := range fpInfoList {
+		idx.Vim[fp.BTCPKs] = int64(fp.ID)
+	}
+
+	return nil
+}

--- a/internal/packages/duty/finality-provider-indexer/indexer/indexer_test.go
+++ b/internal/packages/duty/finality-provider-indexer/indexer/indexer_test.go
@@ -1,0 +1,184 @@
+package indexer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cosmostation/cvms/internal/common"
+	"github.com/cosmostation/cvms/internal/helper/logger"
+	"github.com/cosmostation/cvms/internal/packages/duty/finality-provider-indexer/repository"
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+const BabylonBaseURL = "https://lcd-office.cosmostation.io/babylon-testnet"
+
+var (
+	p = common.Packager{
+		ChainName:    "babylon",
+		ChainID:      "bbn-test-5",
+		ProtocolType: "cosmos",
+		Endpoints: common.Endpoints{
+			RPCs: []string{"https://rpc-office.cosmostation.io/babylon-testnet"},
+			APIs: []string{"https://lcd-office.cosmostation.io/babylon-testnet"},
+		},
+		Logger: logger.GetTestLogger(),
+	}
+)
+
+func TestStart(t *testing.T) {
+	waitingDuration := 60 * time.Second
+	// Step 1: Set up the database
+	tempDBName := "temp"
+	indexerDB, err := common.NewTestLoaclIndexerDB(tempDBName)
+	assert.NoError(t, err)
+
+	p.SetIndexerDB(indexerDB)
+	p.SetRetentionTime("1h")
+	p.IsConsumerChain = false
+
+	// Step 2: Initialize the CheckpointIndexer
+	idx, err := NewFinalityProviderIndexer(p)
+	assert.NoError(t, err)
+
+	// Modify Start() to accept a callback for testing purposes
+	err = idx.Start()
+	assert.NoError(t, err)
+
+	// Step 4: Wait for the goroutine to finish
+	done := make(chan bool)
+
+	go func() {
+		// Simulate some work
+		time.Sleep(waitingDuration)
+		done <- true
+	}()
+
+	<-done
+	t.Log("Goroutine finished work")
+}
+func TestBatchSync(t *testing.T) {
+	tempDBName := "temp"
+	indexerDB, err := common.NewTestLoaclIndexerDB(tempDBName)
+	p.SetIndexerDB(indexerDB)
+	p.IsConsumerChain = false
+	assert.NoError(t, err)
+
+	idx, err := NewFinalityProviderIndexer(p)
+	assert.NoError(t, err)
+
+	err = idx.InitChainInfoID()
+	assert.NoError(t, err)
+
+	err = idx.repo.InitPartitionTablesByChainInfoID(repository.IndexName, idx.ChainID, 100)
+	assert.NoError(t, err)
+
+	err = idx.repo.CreateFinalityProviderInfoPartitionTableByChainID(idx.ChainID)
+	assert.NoError(t, err)
+
+	err = idx.FetchValidatorInfoList()
+	assert.NoError(t, err)
+
+	newIndexPointer, err := idx.batchSync(94810, 94820)
+	assert.NoError(t, err)
+	t.Logf("new index point: %d", newIndexPointer)
+}
+
+func TestGetFinalityProvidersInfo(t *testing.T) {
+	app := common.NewCommonApp(p)
+	app.SetAPIEndPoint(BabylonBaseURL)
+
+	nm := make(map[string]bool, 0)
+	fpInfoList, err := GetFinalityProvidersInfo(app.CommonClient, nm, 1)
+
+	assert.NoError(t, err)
+	t.Logf("new fp infos: %d", len(fpInfoList))
+	for idx, fp := range fpInfoList {
+		t.Logf("fp infos: \n%v", fp)
+
+		if idx == 0 {
+			break
+		}
+	}
+}
+
+func TestCheckMissCounterLogic(t *testing.T) {
+	requester := resty.New().
+		SetBaseURL(BabylonBaseURL).
+		R().
+		SetContext(context.Background())
+
+	// set header for current height
+	heightStr := strconv.FormatInt(47020, 10)
+	header := map[string]string{"Content-Type": "application/json", "x-cosmos-block-height": heightStr}
+	requester.SetHeaders(header)
+
+	resp, err := requester.Get("/babylon/finality/v1/signing_infos")
+	assert.NoErrorf(t, err, "error from : %s", resp.Request.URL)
+
+	fpSigningInfos, err := ParserFinalityProviderSigningInfos(resp.Body())
+	assert.NoErrorf(t, err, "error from : %s", resp.Request.URL)
+
+	for _, fp := range fpSigningInfos.SigningInfos {
+		fmt.Printf("  FP BTC PK Hex: %s\n", fp.FPBTCPkHex)
+		fmt.Printf("  Start Height: %s\n", fp.StartHeight)
+		fmt.Printf("  Missed Blocks Counter: %s\n", fp.MissedBlocksCounter)
+		fmt.Printf("  Jailed Until: %s\n", fp.JailedUntil)
+		break
+	}
+
+	fmt.Println("\nPagination:")
+	fmt.Printf("  Total: %s\n", fpSigningInfos.Pagination.Total)
+}
+
+const TestingHeight = 93329
+
+func TestCheckNonVotingFds(t *testing.T) {
+	requester := resty.New().
+		SetBaseURL(BabylonBaseURL).
+		R().
+		SetContext(context.Background())
+	resp, err := requester.Get(fmt.Sprintf("/babylon/finality/v1/finality_providers/%d", TestingHeight))
+	assert.NoErrorf(t, err, "error from : %s", resp.Request.URL)
+
+	fps, err := ParseFinalityProviders(resp.Body())
+	assert.NoErrorf(t, err, "error from : %s", resp.Request.URL)
+
+	// make a map by fp votes
+	fpVoteMap := make(map[string]bool, len(fps.FinalityProviders))
+	for _, fp := range fps.FinalityProviders {
+		// t.Logf("add a pk_hex into map: %s", fp.BtcPkHex)
+		fpVoteMap[fp.BtcPkHex] = false
+	}
+
+	resp, err = requester.Get(fmt.Sprintf("/babylon/finality/v1/votes/%d", TestingHeight))
+	assert.NoErrorf(t, err, "error from : %s", resp.Request.URL)
+
+	votes, err := ParseFinalityProviderVotings(resp.Body())
+	assert.NoError(t, err)
+
+	// if the pk is existed in the votings, update the value for fp
+	trueCnt := 0
+	for _, pk := range votes.BTCPKs {
+		fpVoteMap[pk] = true
+		trueCnt++
+	}
+
+	// t.Logf("%v", fpVoteMap)
+
+	// Convert the map to JSON and log it
+	jsonData, err := json.MarshalIndent(fpVoteMap, "", "  ") // Indent with 2 spaces
+	if err != nil {
+		t.Logf("Error converting map to JSON: %v", err)
+	} else {
+		t.Logf("fpVoteMap for %d TestingHeight: \n%s", TestingHeight, jsonData)
+	}
+
+	total := len(fps.FinalityProviders)
+	t.Logf("total %d | true :%d / false: %d", total, trueCnt, (total - trueCnt))
+
+}

--- a/internal/packages/duty/finality-provider-indexer/indexer/metrics.go
+++ b/internal/packages/duty/finality-provider-indexer/indexer/metrics.go
@@ -1,0 +1,35 @@
+package indexer
+
+import (
+	"time"
+
+	"github.com/cosmostation/cvms/internal/common"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func (idx *FinalityProviderIndexer) initLabelsAndMetrics() {
+	indexPointerBlockHeightMetric := idx.Factory.NewGauge(prometheus.GaugeOpts{
+		Namespace:   common.Namespace,
+		Subsystem:   subsystem,
+		Name:        common.IndexPointerBlockHeightMetricName,
+		ConstLabels: idx.PackageLabels,
+	})
+
+	latestBlockHeightMetric := idx.Factory.NewGauge(prometheus.GaugeOpts{
+		Namespace:   common.Namespace,
+		Subsystem:   subsystem,
+		Name:        common.LatestBlockHeightMetricName,
+		ConstLabels: idx.PackageLabels,
+	})
+
+	indexPointerBlockHeightMetric.Set(0)
+	idx.MetricsMap[common.IndexPointerBlockHeightMetricName] = indexPointerBlockHeightMetric
+
+	latestBlockHeightMetric.Set(0)
+	idx.MetricsMap[common.LatestBlockHeightMetricName] = latestBlockHeightMetric
+}
+
+func (idx *FinalityProviderIndexer) updatePrometheusMetrics(indexPointer int64, indexPointerTimestamp time.Time) {
+	idx.MetricsMap[common.IndexPointerBlockHeightMetricName].Set(float64(indexPointer))
+	idx.Debugf("update prometheus metrics %d height", indexPointer)
+}

--- a/internal/packages/duty/finality-provider-indexer/model/babylon.go
+++ b/internal/packages/duty/finality-provider-indexer/model/babylon.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type BabylonFinalityProviderVote struct {
+	bun.BaseModel        `bun:"table:babylon_finality_provider"`
+	ID                   int64     `bun:"id,pk,autoincrement"`
+	ChainInfoID          int64     `bun:"chain_info_id,pk,notnull"`
+	Height               int64     `bun:"height,notnull"`
+	FinalityProviderPKID int64     `bun:"finality_provider_pk_id,notnull"`
+	Status               int64     `bun:"status,notnull"`
+	CreatedTime          time.Time `bun:"timestamp,notnull"`
+}
+
+func (bfpv BabylonFinalityProviderVote) String() string {
+	return fmt.Sprintf("BabylonFinalityProviderVote<%d %d %d %d %d>",
+		bfpv.ID,
+		bfpv.ChainInfoID,
+		bfpv.Height,
+		bfpv.FinalityProviderPKID,
+		bfpv.Status,
+	)
+}

--- a/internal/packages/duty/finality-provider-indexer/repository/repository.go
+++ b/internal/packages/duty/finality-provider-indexer/repository/repository.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/cosmostation/cvms/internal/common"
+	idxmodel "github.com/cosmostation/cvms/internal/common/indexer/model"
+	indexerrepo "github.com/cosmostation/cvms/internal/common/indexer/repository"
+	dbhelper "github.com/cosmostation/cvms/internal/helper/db"
+	"github.com/cosmostation/cvms/internal/packages/duty/finality-provider-indexer/model"
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+const IndexName = "babylon_finality_provider"
+
+type FinalityProviderIndexerRepository struct {
+	sqlTimeout time.Duration
+	*bun.DB
+	indexerrepo.IMetaRepository
+}
+
+func NewRepository(indexerDB common.IndexerDB, sqlTimeout time.Duration) FinalityProviderIndexerRepository {
+	// Instantiate the meta repository
+	metarepo := indexerrepo.NewMetaRepository(indexerDB)
+
+	// Return a repository that implements both IMetaRepository and vote-specific logic
+	return FinalityProviderIndexerRepository{sqlTimeout, indexerDB.DB, metarepo}
+}
+
+func (repo *FinalityProviderIndexerRepository) InsertFinalityProviderVoteList(chainInfoID int64, indexPointerHeight int64, bfpvList []model.BabylonFinalityProviderVote) error {
+	ctx, cancel := context.WithTimeout(context.Background(), repo.sqlTimeout)
+	defer cancel()
+
+	// if there are not any miss validators in this block, just update index pointer
+	if len(bfpvList) == 0 {
+		_, err := repo.
+			NewUpdate().
+			Model(&idxmodel.IndexPointer{}).
+			Set("pointer = ?", indexPointerHeight).
+			Where("chain_info_id = ?", chainInfoID).
+			Where("index_name = ?", IndexName).
+			Exec(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update new index pointer")
+		}
+
+		return nil
+	}
+
+	err := repo.RunInTx(
+		ctx,
+		nil,
+		func(ctx context.Context, tx bun.Tx) error {
+			_, err := tx.NewInsert().
+				Model(&bfpvList).
+				ExcludeColumn("id").
+				Exec(ctx)
+			if err != nil {
+				return errors.Wrapf(err, "failed to insert validator_miss list")
+			}
+
+			_, err = tx.
+				NewUpdate().
+				Model(&idxmodel.IndexPointer{}).
+				Set("pointer = ?", indexPointerHeight).
+				Where("chain_info_id = ?", chainInfoID).
+				Where("index_name = ?", IndexName).
+				Exec(ctx)
+			if err != nil {
+				return errors.Wrapf(err, "failed to update new index pointer")
+			}
+
+			return nil
+		})
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to exec validator miss in a transaction: %v", bfpvList)
+	}
+
+	return nil
+}
+
+func (repo *FinalityProviderIndexerRepository) DeleteOldFinalityProviderVoteList(chainID, retentionPeriod string) (
+	/* deleted rows */ int64,
+	/* unexpected error */ error,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), repo.sqlTimeout)
+	defer cancel()
+
+	// Parsing retention period
+	duration, err := dbhelper.ParseRetentionPeriod(retentionPeriod)
+	if err != nil {
+		return 0, err
+	}
+
+	// Calculate cutoff time duration
+	cutoffTime := time.Now().Add(duration)
+
+	// Make partition table name
+	partitionTableName := dbhelper.MakePartitionTableName(IndexName, chainID)
+
+	// Query Execution
+	res, err := repo.NewDelete().
+		Model((*model.BabylonFinalityProviderVote)(nil)).
+		ModelTableExpr(partitionTableName).
+		Where("timestamp < ?", cutoffTime).
+		Exec(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	rowsAffected, _ := res.RowsAffected()
+	return rowsAffected, nil
+}


### PR DESCRIPTION
## PR(Pull Request) Overview

Make a new monitoring package for babylon chain. 

Babylon chain has a third party to operator finality for btcstaking. 

`finality provider indexer` means finality provider vote monitoring tools like voteindexer or tenderduty. 

#### Changes

- [x] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update

#### Related Issue

#24 