### PR TITLE
feat: add helm chart

### DIFF
--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# img folder
+img/
+# Changelog
+CHANGELOG.md

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 16.3.5
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.29.0
+digest: sha256:8c7c60055f2b8834c742f2b389606d430018a7fd08449ce2c8c31b31a94f0ca4
+generated: "2025-01-10T15:05:20.436906+03:30"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: cvms
+description: The Cosmos Validator Monitoring Service (CVMS) is an integrated monitoring system for validators within the Cosmos app chain ecosystem
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+
+dependencies:
+- condition: postgresql.enabled
+  name: postgresql
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 16.x.x
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  tags:
+  - bitnami-common
+  version: 2.x.x

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,130 @@
+# CVMS Helm Chart
+
+This Helm chart is used to deploy the CVMS (Cloud Virtual Management Service) application.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+
+## Installation
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm install my-release cvms/helm
+```
+
+## Uninstallation
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm uninstall my-release
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the CVMS chart and their default values.
+
+| Parameter                | Description                           | Default                        |
+|--------------------------|---------------------------------------|--------------------------------|
+| `imagePullSecrets`       | Image pull secrets                    | `[]`                           |
+| `nameOverride`           | Override the name of the chart        | `""`                           |
+| `fullnameOverride`       | Override the full name of the chart   | `""`                           |
+| `namespaceOverride`      | Override the namespace of the chart   | `""`                           |
+| `customChainsConfig.enabled` | Enable custom chains configuration | `false`                        |
+| `customChainsConfig.name`    | Name of the custom chains configmap | `custom-chains-cm`             |
+| `cvmsConfig.name`        | Name of the CVMS configmap            | `cvms-cm`                      |
+| `cvmsConfig.monikers`    | CVMS config for validator or network mode | `[]`                       |
+| `cvmsConfig.chains`      | CVMS config for monitoring chains     | `[]`                           |
+| `indexer.replicaCount`   | Number of replicas for the indexer    | `1`                            |
+| `indexer.image.repository` | Image repository for the indexer     | `cosmostation/cvms`            |
+| `indexer.image.pullPolicy` | Image pull policy for the indexer    | `Always`                       |
+| `indexer.image.tag`      | Image tag for the indexer             | `latest`                       |
+| `indexer.command`        | Command to run in the indexer container | `["/bin/cvms"]`              |
+| `indexer.args`           | Arguments for the indexer container   | `["start", "indexer", "--config=/var/lib/cvms/config.yaml", "--log-color-disable", "false", "--log-level", "4", "--port=9300"]` |
+| `indexer.env`            | Environment variables for the indexer | `{ DB_RETENTION_PERIOD: 1h }`  |
+| `indexer.revisionHistoryLimit` | Number of old ReplicaSets to retain | `2`                        |
+| `indexer.podAnnotations` | Annotations for the indexer pods      | `{}`                           |
+| `indexer.podLabels`      | Labels for the indexer pods           | `{}`                           |
+| `indexer.podSecurityContext.enabled` | Enable pod security context for the indexer | `false`          |
+| `indexer.securityContext.enabled` | Enable security context for the indexer | `true`                |
+| `indexer.service.type`   | Service type for the indexer          | `ClusterIP`                    |
+| `indexer.service.port`   | Service port for the indexer          | `9300`                         |
+| `indexer.resources.enabled` | Enable resource requests and limits for the indexer | `true`          |
+| `indexer.livenessProbe.enabled` | Enable liveness probe for the indexer | `true`                  |
+| `indexer.readinessProbe.enabled` | Enable readiness probe for the indexer | `true`                |
+| `indexer.volumes`        | Additional volumes for the indexer    | See `values.yaml`              |
+| `indexer.volumeMounts`   | Additional volume mounts for the indexer | See `values.yaml`           |
+| `indexer.nodeSelector`   | Node selector for the indexer pods    | `{}`                           |
+| `indexer.tolerations`    | Tolerations for the indexer pods      | `[]`                           |
+| `indexer.affinity`       | Affinity rules for the indexer pods   | `{}`                           |
+| `indexer.metrics.type`   | Metrics service type for the indexer  | `ClusterIP`                    |
+| `indexer.metrics.servicePort` | Metrics service port for the indexer | `9300`                     |
+| `indexer.serviceMonitor.enabled` | Enable Prometheus ServiceMonitor for the indexer | `false`         |
+| `exporter.replicaCount`  | Number of replicas for the exporter   | `1`                            |
+| `exporter.image.repository` | Image repository for the exporter   | `cosmostation/cvms`            |
+| `exporter.image.pullPolicy` | Image pull policy for the exporter  | `Always`                       |
+| `exporter.image.tag`     | Image tag for the exporter            | `latest`                       |
+| `exporter.command`       | Command to run in the exporter container | `["/bin/cvms"]`            |
+| `exporter.args`          | Arguments for the exporter container  | `["start", "exporter", "--config=/var/lib/cvms/config.yaml", "--log-color-disable", "false", "--log-level", "4", "--port=9200"]` |
+| `exporter.env`           | Environment variables for the exporter | `{}`                          |
+| `exporter.revisionHistoryLimit` | Number of old ReplicaSets to retain | `2`                        |
+| `exporter.podAnnotations` | Annotations for the exporter pods    | `{}`                           |
+| `exporter.podLabels`     | Labels for the exporter pods          | `{}`                           |
+| `exporter.podSecurityContext.enabled` | Enable pod security context for the exporter | `false`        |
+| `exporter.securityContext.enabled` | Enable security context for the exporter | `true`              |
+| `exporter.service.type`  | Service type for the exporter         | `ClusterIP`                    |
+| `exporter.service.port`  | Service port for the exporter         | `9200`                         |
+| `exporter.resources.enabled` | Enable resource requests and limits for the exporter | `true`        |
+| `exporter.livenessProbe.enabled` | Enable liveness probe for the exporter | `true`                |
+| `exporter.readinessProbe.enabled` | Enable readiness probe for the exporter | `true`              |
+| `exporter.volumes`       | Additional volumes for the exporter   | See `values.yaml`              |
+| `exporter.volumeMounts`  | Additional volume mounts for the exporter | See `values.yaml`           |
+| `exporter.nodeSelector`  | Node selector for the exporter pods   | `{}`                           |
+| `exporter.tolerations`   | Tolerations for the exporter pods     | `[]`                           |
+| `exporter.affinity`      | Affinity rules for the exporter pods  | `{}`                           |
+| `exporter.metrics.type`  | Metrics service type for the exporter | `ClusterIP`                    |
+| `exporter.metrics.servicePort` | Metrics service port for the exporter | `9200`                   |
+| `exporter.serviceMonitor.enabled` | Enable Prometheus ServiceMonitor for the exporter | `false`       |
+| `postgresql.enabled`     | Enable PostgreSQL                     | `true`                         |
+| `postgresql.auth.username` | PostgreSQL username                 | `cvms`                         |
+| `postgresql.auth.password` | PostgreSQL password                 | `mysecretpassword`             |
+| `postgresql.auth.database` | PostgreSQL database                 | `cvms`                         |
+| `postgresql.architecture` | PostgreSQL architecture              | `standalone`                   |
+| `postgresql.primary.resourcesPreset` | PostgreSQL primary resources preset | `nano`                 |
+| `postgresql.primary.resources` | PostgreSQL primary resources    | `{}`                           |
+| `postgresql.primary.persistence.storageClass` | PostgreSQL primary storage class | `""`              |
+| `postgresql.primary.persistence.size` | PostgreSQL primary storage size | `500Mi`                   |
+| `postgresql.external.host` | External PostgreSQL host            | `""`                           |
+| `postgresql.external.port` | External PostgreSQL port            | `5432`                         |
+| `postgresql.external.user` | External PostgreSQL user            | `cvms`                         |
+| `postgresql.external.password` | External PostgreSQL password    | `""`                           |
+| `postgresql.external.database` | External PostgreSQL database    | `cvms`                         |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```bash
+helm install my-release /path/to/cvms --set indexer.image.tag=1.0.0 --set exporter.image.tag=1.0.0
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example:
+
+```bash
+helm install my-release /path/to/cvms -f values.yaml
+```
+
+### Detailed Configuration
+
+Below is a more detailed explanation of the values that can be set in the `values.yaml` file:
+
+- `image.repository`: The Docker image repository for the CVMS application.
+- `image.tag`: The tag of the Docker image to use.
+- `image.pullPolicy`: The Kubernetes image pull policy.
+- `service.type`: The type of Kubernetes service to create (e.g., `ClusterIP`, `NodePort`, `LoadBalancer`).
+- `service.port`: The port on which the service will be exposed.
+- `resources`: Resource requests and limits for the CVMS pods.
+- `nodeSelector`: Node labels for pod assignment.
+- `tolerations`: Tolerations for pod assignment.
+- `affinity`: Affinity rules for pod assignment.

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # CVMS Helm Chart
 
-This Helm chart is used to deploy the CVMS (Cloud Virtual Management Service) application.
+The Cosmos Validator Monitoring Service (CVMS) is an integrated monitoring system for validators within the Cosmos app chain ecosystem. This helm chart is fot installing cvms on kubernetes.
 
 ## Prerequisites
 
@@ -26,6 +26,8 @@ helm uninstall my-release
 ## Configuration
 
 The following table lists the configurable parameters of the CVMS chart and their default values.
+
+**Note**: You must provide cvmsConfig.monikers and cvmsConfig.chains for monitoring Cosmos validators with cvms, checkout the example in https://github.com/cosmostation/cvms/blob/release/docs/setup.md
 
 | Parameter                | Description                           | Default                        |
 |--------------------------|---------------------------------------|--------------------------------|

--- a/helm/files/axelar-evm.yaml
+++ b/helm/files/axelar-evm.yaml
@@ -1,0 +1,10 @@
+groups:
+  - name: AxelarEVMPackage
+    rules:
+      - alert: AxelarEVMChainMaintainerInactive
+        expr: cvms_axelar_evm_maintainer_status == 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Axelar EVM Maintainer for {{ $labels.evm_chain }} is inactive in {{ $labels.chain_id }}'

--- a/helm/files/balance.yaml
+++ b/helm/files/balance.yaml
@@ -1,0 +1,34 @@
+groups:
+  - name: BalancePackage
+    rules:
+      - alert: AxelarEVMBroadcasterBalanceUnder10
+        expr: cvms_balance_remaining_amount{balance_address='axelar146kdz9stlycvacm03hg0t5fxq6jszlc4gtxgpr'} < 10
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: 'The broadcaster ({{ $labels.balance_address }}) has less than 10 tokens remaining. Current balance: {{ $value }}'
+
+      - alert: KavaOracleBroadcasterBalanceUnder10
+        expr: cvms_balance_remaining_amount{balance_address='kava1ujfrlcd0ted58mzplnyxzklsw0sqevlgxndanp'} < 10
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: 'The broadcaster ({{ $labels.balance_address }}) has less than 10 tokens remaining. Current balance: {{ $value }}'
+
+      - alert: InjectiveEventnonceBroadcasterBalanceUnder1
+        expr: cvms_balance_remaining_amount{balance_address='inj1mtxhcchfyvvs6u4nmnylgkxvkrax7c2la69l8w'} < 1
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: 'The broadcaster ({{ $labels.balance_address }}) has less than 1 tokens remaining. Current balance: {{ $value }}'
+
+      - alert: NibiruOracleBroadcasterBalanceUnder10
+        expr: cvms_balance_remaining_amount{balance_address='nibi14zc23q3qcewscy7wnt3s95h32chytenqxe633l'} < 10
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: 'The broadcaster ({{ $labels.balance_address }}) has less than 10 tokens remaining. Current balance: {{ $value }}'

--- a/helm/files/block.yaml
+++ b/helm/files/block.yaml
@@ -1,0 +1,22 @@
+groups:
+  - name: BlockPackage
+    rules:
+      - alert: LastestBlockTimeDiffOver60s
+        expr: (time() - cvms_block_timestamp) > 60
+        for: 30s
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Latest Block Timestamp is over 60 seconds from now'
+          description: |
+            The block timestamp for the {{ $labels.chain }} chain at {{ $labels.endpoint }} has exceeded 60 seconds. Please check the synchronization status of the node.
+
+      - alert: LastestBlockTimeDiffOver300s
+        expr: (time() - cvms_block_timestamp) > 300
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'The {{ $labels.chain }}-{{ $labels.chain_id }} latest block timestamp has exceeded 5 minutes'
+          description: |
+            The block timestamp at {{ $labels.endpoint }} has exceeded 5 minutes. Please check the node's synchronization status immediately.

--- a/helm/files/consensus-vote.yaml
+++ b/helm/files/consensus-vote.yaml
@@ -1,0 +1,18 @@
+groups:
+  - name: VoteIndexerPackage
+    rules:
+      - alert: VoteIndexerSyncSlow
+        expr: (time() - cvms_consensus_vote_latest_index_pointer_block_timestamp) > 300
+        for: 30s
+        labels:
+          severity: warning
+        annotations:
+          summary: The Vote Indexer Package sync is slow to sync blocks for {{ $labels.chain_id }}
+
+      - alert: IncreaseRecentConsensusVoteMiss
+        expr: increase(cvms_consensus_vote_recent_miss_counter[1m]) > 15
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: The validator is missing too many votes in the consensus for {{ $labels.chain_id }}

--- a/helm/files/custom_chains.yaml.example
+++ b/helm/files/custom_chains.yaml.example
@@ -1,0 +1,12 @@
+---
+mintstation-1:
+  protocol_type: cosmos
+  support_asset:
+    denom: umint
+    decimal: 6
+  packages:
+    - block
+    - upgrade
+    - uptime
+    - voteindexer #for cometbft consensus vote
+    - veindexer # for vote-extension

--- a/helm/files/eventnonce.yaml
+++ b/helm/files/eventnonce.yaml
@@ -1,0 +1,21 @@
+groups:
+  - name: EventNoncePackage
+    rules:
+      - alert: CosmosEventNonceDiffOver0
+        expr: (cvms_eventnonce_highest_nonce - on (chain_id) group_right cvms_eventnonce_nonce) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Validator node event nonce is behind in {{ $labels.chain }}'
+          description: '{{ $labels.chain }} has an event nonce that is {{ $value }} behind other validators.'
+
+      - alert: CosmosEventNonceDiffOver1h
+        expr: (cvms_eventnonce_highest_nonce - on (chain_id) group_right cvms_eventnonce_nonce) > 0
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Validator node event nonce is behind in {{ $labels.chain }} during 1h'
+          description: |
+            The event nonce for {{ $labels.chain }} is more than {{ $value }} behind other validators. Immediate action is required.

--- a/helm/files/extension-vote.yaml
+++ b/helm/files/extension-vote.yaml
@@ -1,0 +1,18 @@
+groups:
+  - name: VoteExtensionIndexerPackage
+    rules:
+      - alert: VoteExtensionIndexerSyncSlow
+        expr: (time() - cvms_extension_vote_latest_index_pointer_block_timestamp) > 300
+        for: 30s
+        labels:
+          severity: warning
+        annotations:
+          summary: The Vote Extension Indexer Package sync is slow to sync blocks for {{ $labels.chain_id }}
+
+      - alert: IncreaseRecentExtensionVoteMiss
+        expr: increase(cvms_extension_vote_recent_miss_counter[1m]) > 15
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: The validator is missing too many votes in the extension voting for {{ $labels.chain_id }}

--- a/helm/files/oracle.yaml
+++ b/helm/files/oracle.yaml
@@ -1,0 +1,26 @@
+groups:
+  - name: OraclePackage
+    rules:
+      - alert: IncreasingMissCounterOver30%During1h
+        expr: (delta(cvms_oracle_miss_counter[1h]) / on (chain_id) group_left delta(cvms_oracle_block_height[1h])) * on (chain_id) group_left cvms_oracle_vote_period > 0.30
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: The Oracle Miss Counter for the network {{ $labels.chain }}-{{ $labels.chain_id }} is increasing by over 30% during the past hour
+
+      - alert: OracleUptimeUnder50%
+        expr: |
+          (
+            (cvms_oracle_vote_window - on (chain_id) group_right () cvms_oracle_miss_counter)
+              / on (chain_id) group_left ()
+            cvms_oracle_vote_window
+          ) < 0.5
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: The Validator's Oracle vote rate is too low for the {{ $labels.chain }}-{{ $labels.chain_id }} network
+          description: |
+            Oracle vote rate has dropped below 50%, indicating severe issues with the validator's participation.
+            Current vote rate: {{ $value | humanizePercentage }}

--- a/helm/files/root.yaml
+++ b/helm/files/root.yaml
@@ -1,0 +1,54 @@
+groups:
+  - name: Prometheus
+    rules:
+      - alert: CVMSExporterDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'One of CVMS Service was down.'
+          description: |
+            The {{ $labels.job }} was down. you should recover this service right now to keep CVMS monitoring service.
+
+      - alert: FoundFailedEvaluationRules
+        expr: increase(prometheus_rule_evaluation_failures_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Prometheus rule evaluation failures detected in CVMS.'
+          description: |
+            Some of rules in {{ $labels.rule_group }} is not normal. Please check the rules ASAP to monitor normally.
+
+  - name: Root
+    rules:
+      - alert: AbnormalPackageOperations
+        expr: changes(cvms_root_processed_ops_total[3m]) < 1
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: summary: 'No package operations detected in CVMS service.'
+          description: |
+            The {{ $labels.package }} service being collected from {{ $labels.chain }} is not operating correctly.
+
+      - alert: FoundUnhealthyPackage
+        expr: cvms_root_health_checker == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'There are abnormal packages in the CVMS service.'
+          description: |
+            Health check failed for {{ $labels.package }} service on chain {{ $labels.chain }}. Verify service health metrics.
+
+      - alert: FoundSkippedPackage
+        expr: cvms_root_skip_counter == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'There are skipped packages in the CVMS service.'
+          description: |
+            Package {{ $labels.package }} on instance {{ $labels.instance_name }} has been skipped. Check for configuration issues or resource constraints.

--- a/helm/files/upgrade.yaml
+++ b/helm/files/upgrade.yaml
@@ -1,0 +1,26 @@
+groups:
+  - name: Upgrade
+    rules:
+      - alert: OnchainUpgradeRegistered
+        expr: (cvms_upgrade_remaining_time - cvms_upgrade_remaining_time offset 30m > 3600) and (cvms_upgrade_remaining_time offset 30m == 0)
+        labels:
+          severity: info
+          channel: upgrade
+        annotations:
+          summary: 'An upgrade named {{ $labels.upgrade_name }} has been registered on the {{ $labels.chain }}-{{ $labels.chain_id }} network.'
+
+      - alert: onchain_upgrade_remaining_3h
+        expr: cvms_upgrade_remaining_time != 0 and cvms_upgrade_remaining_time < 10800
+        labels:
+          severity: info
+          channel: upgrade
+        annotations:
+          summary: 'The upgrade {{ $labels.upgrade_name }} on the {{ $labels.chain }}-{{ $labels.chain_id }} network is approximately 3 hours away.'
+
+      - alert: onchain_upgrade_remaining_1h
+        expr: cvms_upgrade_remaining_time != 0 and cvms_upgrade_remaining_time < 3600
+        annotations:
+          summary: 'The upgrade {{ $labels.upgrade_name }} on the {{ $labels.chain }}-{{ $labels.chain_id }} network is approximately 1 hour away.'
+        labels:
+          severity: info
+          channel: upgrade

--- a/helm/files/uptime.yaml
+++ b/helm/files/uptime.yaml
@@ -1,0 +1,29 @@
+groups:
+  - name: UptimePackage
+    rules:
+      - alert: IncreasingMissCounterOver30%During1h
+        expr: |
+          # 30mins ago, the validator is unjailed. but got jailed 
+          cvms_uptime_jailed - cvms_uptime_jailed offset 30m > 0 and (cvms_uptime_jailed offset 30m == 0)
+        labels:
+          severity: critical
+        annotations:
+          summary: The validator is jailed now in {{ $labels.chain_id }}
+
+      - alert: UptimeMissCounterIsIncreasing10%During1h
+        expr: |
+          # miss counter during 1h / blocks during 1h
+          (delta(cvms_uptime_missed_blocks_counter[1h]) / on (chain_id) group_left max by (chain_id) (delta(cvms_block_height[1h]))) > 0.1
+        labels:
+          severity: critical
+        annotations:
+          summary: The Validator's uptime is decreasing now! Check your validator in {{ $labels.chain }}-{{ $labels.chain_id }} network
+
+      - alert: Remaining1000BlocksBeforeGettingSlashing
+        expr: |
+          # max missed - current missed 
+          ceil(cvms_uptime_signed_blocks_window * (1 - cvms_uptime_min_signed_per_window)) - on (chain_id) group_right () cvms_uptime_missed_blocks_counter < 1000
+        labels:
+          severity: critical
+        annotations:
+          summary: The Validator is missing too many blocks! Check your validator in {{ $labels.chain }}-{{ $labels.chain_id }} network

--- a/helm/files/yoda.yaml
+++ b/helm/files/yoda.yaml
@@ -1,0 +1,10 @@
+groups:
+  - name: YodaPackage
+    rules:
+      - alert: BandYodaStatusInactivated
+        expr: cvms_yoda_status == 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'The Yoda status of the validator has been deactivated in the {{ $labels.chain }}-{{ $labels.chain_id }} network'

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,11 @@
+1. Get the application URL by running these commands:
+
+    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+                You can watch the status of by running 'kubectl get svc -w'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cvms.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo http://$SERVICE_IP:{{ .Values.indexer.service.port }}
+
+2. To delete the release, run:
+
+    helm delete {{ .Release.Name }} --namespace {{ .Release.Namespace }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -76,6 +76,15 @@ app.kubernetes.io/metrics-instance: {{ .Release.Name }}-exporter
 {{- end }}
 
 {{/*
+Fail the Helm chart if monikers is an empty list
+*/}}
+{{- define "validateMonikers" -}}
+{{- if eq (len .Values.cvmsConfig.monikers) 0 }}
+{{- fail "The 'monikers' list in 'cvmsConfig' must not be empty. Please provide at least one moniker." }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,123 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cvms.name" -}}
+{{- coalesce .Release.Name .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cvms.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cvms.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cvms.labels" -}}
+helm.sh/chart: {{ include "cvms.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Metrics labels for indexer
+*/}}
+{{- define "cvms.indexerSelectorMetricLabels" -}}
+app.kubernetes.io/metrics-name: {{ include "cvms.name" . }}-indexer
+app.kubernetes.io/metrics-instance: {{ .Release.Name }}-indexer
+{{- end }}
+
+{{/*
+Metrics labels for exporter
+*/}}
+{{- define "cvms.exporterSelectorMetricLabels" -}}
+app.kubernetes.io/metrics-name: {{ include "cvms.name" . }}-exporter
+app.kubernetes.io/metrics-instance: {{ .Release.Name }}-exporter
+{{- end }}
+
+{{- if and (not .Values.postgresql.enabled) (not .Values.postgresql.external.host) -}}
+{{- fail "NO DATABASE: You disabled the PostgreSQL sub-chart but did not specify an external PostgreSQL host. Either deploy the PostgreSQL sub-chart by setting postgresql.enabled=true or set a value for postgresql.external.host." -}}
+{{- end }}
+
+{{- if and .Values.postgresql.enabled .Values.postgresql.external.host -}}
+{{- fail "CONFLICT: You specified to deploy the PostgreSQL sub-chart and also specified an external PostgreSQL instance. Only one of postgresql.enabled (deploy sub-chart) and postgresql.external.host can be set." -}}
+{{- end }}
+
+{{- if .Values.customChainsConfig.enabled -}}
+{{- if not .Values.customChainsConfig.name -}}
+{{- fail "A name is required for customChainsConfig when enabled" -}}
+{{- end }}
+{{- end }}
+
+{{- if not .Values.cvmsConfig.name }}
+{{- fail "A name is required for cvmsConfig" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cvms.postgresql.fullname" -}}
+{{- include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) -}}
+{{- end -}}
+
+{{/*
+Get PostgreSQL host
+*/}}
+{{- define "cvms.postgresql.host" -}}
+{{- ternary (include "cvms.postgresql.fullname" .) .Values.postgresql.external.host .Values.postgresql.enabled | quote -}}
+{{- end -}}
+
+{{/*
+Get PostgreSQL port
+*/}}
+{{- define "cvms.postgresql.port" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- default "5432"  .Values.postgresql.port | quote -}}
+{{- else -}}
+    {{- default "5432"  .Values.postgresql.external.port | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get PostgreSQL user
+*/}}
+{{- define "cvms.postgresql.user" -}}
+{{- ternary .Values.postgresql.auth.username .Values.postgresql.external.user .Values.postgresql.enabled | quote -}}
+{{- end -}}
+
+{{/*
+Get PostgreSQL password
+*/}}
+{{- define "cvms.postgresql.password" -}}
+{{- ternary .Values.postgresql.auth.password .Values.postgresql.external.password .Values.postgresql.enabled | quote -}}
+{{- end -}}
+
+{{/*
+Get PostgreSQL database
+*/}}
+{{- define "cvms.postgresql.database" -}}
+{{- ternary .Values.postgresql.auth.database .Values.postgresql.external.database .Values.postgresql.enabled | quote -}}
+{{- end -}}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.cvmsConfig.name }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+  labels:
+    {{- include "cvms.labels" . | nindent 4 }}
+    {{- with .Values.cvmsConfig.extraLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.cvmsConfig.annotations }}
+  annotations:
+{{ toYaml .Values.cvmsConfig.annotations | indent 4 }}
+{{- end }}
+data:
+  config.yaml: |
+    monikers: {{ .Values.cvmsConfig.monikers | toJson }}
+
+    chains: {{- if .Values.cvmsConfig.chains }}
+      {{- .Values.cvmsConfig.chains | toYaml | nindent 6 }}
+    {{- else }} []
+    {{- end }}
+

--- a/helm/templates/custom-configmap.yaml
+++ b/helm/templates/custom-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.customChainsConfig.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.customChainsConfig.name }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+  labels:
+    {{- include "cvms.labels" . | nindent 4 }}
+    {{- with .Values.customChainsConfig.extraLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.customChainsConfig.annotations }}
+  annotations:
+    {{ toYaml .Values.customChainsConfig.annotations | indent 4 }}
+  {{- end }}
+data:
+  custom_chains.yaml.example: |
+    {{- .Files.Get "files/custom_chains.yaml.example" | nindent 4 }}
+{{- end }}

--- a/helm/templates/exporter/deployment.yaml
+++ b/helm/templates/exporter/deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cvms.fullname" . }}-exporter
+  labels:
+    {{- include "cvms.labels" . | nindent 4 }}
+    {{- include "cvms.exporterSelectorMetricLabels" . | nindent 4 }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+spec:
+  replicas: {{ .Values.exporter.replicaCount }}
+  revisionHistoryLimit: {{ .Values.exporter.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "cvms.exporterSelectorMetricLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.exporter.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cvms.labels" . | nindent 8 }}
+        {{- include "cvms.exporterSelectorMetricLabels" . | nindent 8 }}
+        {{- with .Values.exporter.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.exporter.podSecurityContext.enabled }}
+      securityContext:
+        {{- toYaml .Values.exporter.podSecurityContext.yamlSyntax | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "cvms.fullname" . }}-exporter
+          {{- if .Values.exporter.securityContext.enabled }}
+          securityContext:
+            {{- toYaml .Values.exporter.securityContext.yamlSyntax | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
+          {{- with .Values.exporter.command }}
+          command:
+          {{- range . }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.exporter.args }}
+          args:
+          {{- range . }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if (ne (len .Values.exporter.env) 0) }}
+          env:
+          {{- range $key, $value := .Values.exporter.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+          {{- end }}
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.exporter.metrics.servicePort }}
+              protocol: TCP
+          {{- if .Values.exporter.livenessProbe.enabled }}
+          livenessProbe:
+            {{- toYaml .Values.exporter.livenessProbe.yamlSyntax | nindent 12 }}
+          {{- end }}
+          {{- if .Values.exporter.readinessProbe.enabled }}
+          readinessProbe:
+            {{- toYaml .Values.exporter.readinessProbe.yamlSyntax | nindent 12 }}
+          {{- end }}
+          {{- if .Values.exporter.resources.enabled }}
+          resources:
+            {{- toYaml .Values.exporter.resources.yamlSyntax | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.customChainsConfig.enabled .Values.exporter.volumeMounts }}
+          volumeMounts:
+          {{- end }}
+          {{- with .Values.exporter.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.customChainsConfig.enabled }}
+            - mountPath: /var/lib/cvms/docker/cvms/custom_chains.yaml
+              name: custom-chains-cm
+              readOnly: true
+              subPath: custom_chains.yaml
+          {{- end }}
+      {{- if or .Values.customChainsConfig.enabled .Values.exporter.volumes }}
+      volumes:
+      {{- end }}
+      {{- with .Values.exporter.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.customChainsConfig.enabled }}
+        - configMap:
+            items:
+            - key: custom_chains.yaml.example
+              path: custom_chains.yaml
+            name: {{ .Values.customChainsConfig.name }}
+          name: custom-chains-cm
+      {{- end }}
+      {{- with .Values.exporter.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.exporter.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.exporter.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/templates/exporter/deployment.yaml
+++ b/helm/templates/exporter/deployment.yaml
@@ -1,3 +1,4 @@
+{{ include "validateMonikers" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/exporter/metrics.yaml
+++ b/helm/templates/exporter/metrics.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cvms.fullname" . }}-exporter-metrics
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+  labels:
+    {{- include "cvms.exporterSelectorMetricLabels" . | nindent 4 }}
+    {{- with .Values.exporter.metrics.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.exporter.metrics.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.exporter.metrics.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.exporter.metrics.type }}
+  {{- if and .Values.exporter.metrics.clusterIP (eq .Values.exporter.metrics.type "ClusterIP") }}
+  clusterIP: {{ .Values.exporter.metrics.clusterIP }}
+  {{- end }}
+  ports:
+  - name: {{ .Values.exporter.metrics.portName }}
+    protocol: TCP
+    port: {{ .Values.exporter.metrics.servicePort }}
+    targetPort: metrics
+  selector:
+    {{- include "cvms.exporterSelectorMetricLabels" . | nindent 4 }}

--- a/helm/templates/exporter/servicemonitor.yaml
+++ b/helm/templates/exporter/servicemonitor.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.exporter.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cvms.fullname" . }}-exporter
+  namespace: {{ default .Release.Namespace .Values.exporter.serviceMonitor.namespace | quote }}
+  labels:
+    {{- include "cvms.labels" . | nindent 4 }}
+    {{- include "cvms.exporterSelectorMetricLabels" . | nindent 4 }}
+    {{- with .Values.exporter.metrics.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.exporter.serviceMonitor.selector }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.exporter.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.exporter.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: {{ .Values.exporter.metrics.portName }}
+      {{- with .Values.exporter.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.exporter.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.exporter.serviceMonitor.path }}
+      path: {{ . }}
+      {{- end }}
+      {{- with .Values.exporter.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.exporter.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.exporter.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.exporter.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+  selector:
+    matchLabels:
+      {{- include "cvms.exporterSelectorMetricLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/templates/indexer/deployment.yaml
+++ b/helm/templates/indexer/deployment.yaml
@@ -1,0 +1,141 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cvms.fullname" . }}-indexer
+  labels:
+    {{- include "cvms.labels" . | nindent 4 }}
+    {{- include "cvms.indexerSelectorMetricLabels" . | nindent 4 }}
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+spec:
+  replicas: {{ .Values.indexer.replicaCount }}
+  revisionHistoryLimit: {{ .Values.indexer.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "cvms.indexerSelectorMetricLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.indexer.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cvms.labels" . | nindent 8 }}
+        {{- include "cvms.indexerSelectorMetricLabels" . | nindent 8 }}
+        {{- with .Values.indexer.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.indexer.initContainers.enabled }}
+      initContainers:
+      {{- range .Values.indexer.initContainers.containers }}
+        - name: {{ .name }}
+          image: {{ .image }}
+          imagePullPolicy: {{ .imagePullPolicy }}
+          command: 
+          {{- toYaml .command | nindent 10 }}
+          args:
+          {{- toYaml .args | nindent 10 }}
+          volumeMounts:
+          {{- range .volumeMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath | quote }}
+          {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.indexer.podSecurityContext.enabled }}
+      securityContext:
+        {{- toYaml .Values.indexer.podSecurityContext.yamlSyntax | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "cvms.fullname" . }}-indexer
+          {{- if .Values.indexer.securityContext.enabled }}
+          securityContext:
+            {{- toYaml .Values.indexer.securityContext.yamlSyntax | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.indexer.image.repository }}:{{ .Values.indexer.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.indexer.image.pullPolicy }}
+          {{- with .Values.indexer.command }}
+          command:
+          {{- range . }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.indexer.args }}
+          args:
+          {{- range . }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- end }}
+          env:
+            - name: DB_HOST
+              value: {{ include "cvms.postgresql.host" . }}
+            - name: DB_NAME
+              value: {{ include "cvms.postgresql.database" . }}
+            - name: DB_PASSWORD
+              value: {{ include "cvms.postgresql.password" . }}
+            - name: DB_PORT
+              value: {{ include "cvms.postgresql.port" . }}
+            - name: DB_USER
+              value: {{ include "cvms.postgresql.user" . }}
+          {{- range $key, $value := .Values.indexer.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.indexer.metrics.servicePort }}
+              protocol: TCP
+          {{- if .Values.indexer.livenessProbe.enabled }}
+          livenessProbe:
+            {{- toYaml .Values.indexer.livenessProbe.yamlSyntax | nindent 12 }}
+          {{- end }}
+          {{- if .Values.indexer.readinessProbe.enabled }}
+          readinessProbe:
+            {{- toYaml .Values.indexer.readinessProbe.yamlSyntax | nindent 12 }}
+          {{- end }}
+          {{- if .Values.indexer.resources.enabled }}
+          resources:
+            {{- toYaml .Values.indexer.resources.yamlSyntax | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.customChainsConfig.enabled .Values.indexer.volumeMounts }}
+          volumeMounts:
+          {{- end }}
+          {{- with .Values.indexer.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.customChainsConfig.enabled }}
+            - mountPath: /var/lib/cvms/docker/cvms/custom_chains.yaml
+              name: custom-chains-cm
+              readOnly: true
+              subPath: custom_chains.yaml
+          {{- end }}
+      {{- if or .Values.customChainsConfig.enabled .Values.indexer.volumes }}
+      volumes:
+      {{- end }}
+      {{- with .Values.indexer.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.customChainsConfig.enabled }}
+        - configMap:
+            items:
+            - key: custom_chains.yaml.example
+              path: custom_chains.yaml
+            name: {{ .Values.customChainsConfig.name }}
+          name: custom-chains-cm
+      {{- end }}
+      {{- with .Values.indexer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.indexer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.indexer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/templates/indexer/metrics.yaml
+++ b/helm/templates/indexer/metrics.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cvms.fullname" . }}-indexer-metrics
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+  labels:
+    {{- include "cvms.indexerSelectorMetricLabels" . | nindent 4 }}
+    {{- with .Values.indexer.metrics.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.indexer.metrics.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.indexer.metrics.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.indexer.metrics.type }}
+  {{- if and .Values.indexer.metrics.clusterIP (eq .Values.indexer.metrics.type "ClusterIP") }}
+  clusterIP: {{ .Values.indexer.metrics.clusterIP }}
+  {{- end }}
+  ports:
+  - name: {{ .Values.indexer.metrics.portName }}
+    protocol: TCP
+    port: {{ .Values.indexer.metrics.servicePort }}
+    targetPort: metrics
+  selector:
+    {{- include "cvms.indexerSelectorMetricLabels" . | nindent 4 }}

--- a/helm/templates/indexer/servicemonitor.yaml
+++ b/helm/templates/indexer/servicemonitor.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.indexer.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cvms.fullname" . }}-indexer
+  namespace: {{ default .Release.Namespace .Values.indexer.serviceMonitor.namespace | quote }}
+  labels:
+    {{- include "cvms.labels" . | nindent 4 }}
+    {{- include "cvms.indexerSelectorMetricLabels" . | nindent 4 }}
+    {{- with .Values.indexer.metrics.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.indexer.serviceMonitor.selector }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.indexer.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.indexer.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: {{ .Values.indexer.metrics.portName }}
+      {{- with .Values.indexer.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.indexer.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.indexer.serviceMonitor.path }}
+      path: {{ . }}
+      {{- end }}
+      {{- with .Values.indexer.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.indexer.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.indexer.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.indexer.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+  selector:
+    matchLabels:
+      {{- include "cvms.indexerSelectorMetricLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/templates/prometheus-rules.yaml
+++ b/helm/templates/prometheus-rules.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.exporter.serviceMonitor.enabled .Values.exporter.serviceMonitor.prometheusRule.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "cvms.labels" . | nindent 4 }}
+    {{- include "cvms.exporterSelectorMetricLabels" . | nindent 4 }}
+    {{- with .Values.exporter.metrics.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.exporter.serviceMonitor.prometheusRule.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.exporter.serviceMonitor.prometheusRule.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "cvms.fullname" . }}
+  namespace: {{ coalesce .Values.exporter.serviceMonitor.prometheusRule.namespace .Values.exporter.serviceMonitor.namespace .Release.Namespace | quote }}
+spec:
+  groups:
+{{- $files := .Files }}
+{{- range .Values.exporter.serviceMonitor.prometheusRule.ruleSets }}
+  {{- if .enabled }}
+    {{- $filePath := printf "files/%s.yaml" .name }}
+    {{- $fileContent := $files.Get $filePath | default "" }}
+    {{- if $fileContent }}
+      {{- $parsedYaml := fromYaml $fileContent }}
+      {{- range $parsedYaml.groups }}
+    - name: {{ .name }}
+      rules:
+      {{- toYaml .rules | nindent 8 }}
+      {{- end }}
+    {{- else }}
+      {{ printf "Warning: File %s not found or empty" $filePath | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+  {{- if .Values.exporter.serviceMonitor.prometheusRule.rules }}
+    - name: {{ include "cvms.fullname" . }}
+      rules: {{- toYaml .Values.exporter.serviceMonitor.prometheusRule.rules | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/sql-schema-configmap.yaml
+++ b/helm/templates/sql-schema-configmap.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-init-script
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+data:
+  init-schema.sh: |
+    #!/bin/sh
+
+    # Exit on error
+    set -e
+
+    # Variables
+    DB_HOST={{ include "cvms.postgresql.host" . }}
+    DB_PORT={{ include "cvms.postgresql.port" . }}
+    DB_USER={{ include "cvms.postgresql.user" . }}
+    DB_NAME={{ include "cvms.postgresql.database" . }}
+    DB_PASSWORD={{ include "cvms.postgresql.password" . }}
+
+    # GitHub API URL for the schema directory
+    SCHEMA_API_URL="https://api.github.com/repos/cosmostation/cvms/contents/docker/postgres/schema"
+
+    # Fetch schema URLs dynamically
+    echo "Fetching schema URLs from GitHub..."
+    SCHEMA_URLS=$(curl -s "$SCHEMA_API_URL" | jq -r '.[].download_url')
+
+    echo "Found the following schema files:"
+    echo "$SCHEMA_URLS"
+
+    # Wait for PostgreSQL to be ready
+    echo "Waiting for PostgreSQL to be ready..."
+    until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER"; do
+      sleep 2
+    done
+
+    echo "PostgreSQL is ready. Applying schemas..."
+
+    # Loop through the list of URLs
+    for SCHEMA_URL in $SCHEMA_URLS; do
+      SCHEMA_FILE="$(basename $SCHEMA_URL)"
+      
+      echo "Downloading schema from $SCHEMA_URL..."
+      curl -s -o "$SCHEMA_FILE" "$SCHEMA_URL"
+
+      echo "Applying schema: $SCHEMA_FILE"
+      PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -f "$SCHEMA_FILE"
+    done
+
+    echo "All schemas applied successfully."

--- a/helm/templates/support_chains-cm.yaml
+++ b/helm/templates/support_chains-cm.yaml
@@ -1,0 +1,1330 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "cvms.labels" . | nindent 4 }}
+  name: support-chains-cm
+  namespace: {{ default .Release.Namespace .Values.namespaceOverride | quote }}
+data:
+  support_chains.yaml: |
+    ---
+    0x5ec: #1516
+      chain_name: story
+      protocol_type: ethereum
+      mainnet: false
+      packages:
+        - block
+    agoric-3:
+      chain_name: agoric
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ubld
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    akashnet-2:
+      chain_name: akash
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uakt
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    allora-testnet-1:
+      chain_name: allora
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uallo
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    althea_258432-1:
+      chain_name: althea
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: aalthea
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    archway-1:
+      chain_name: archway
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: aarch
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    artela_11820-1:
+      chain_name: artela
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uart
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    artela_11822-1:
+      chain_name: artela
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uart
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    atlantic-2:
+      chain_name: sei
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: usei
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - oracle
+        - voteindexer
+    atomone-1:
+      chain_name: atomone
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uatone
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+    axelar-dojo-1:
+      chain_name: axelar
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uaxl
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - axelar-evm
+        - voteindexer
+    axelar-testnet-lisbon-3:
+      chain_name: axelar
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uaxl
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - axelar-evm
+        - voteindexer
+    band-laozi-testnet6:
+      chain_name: band
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uband
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - yoda
+        - voteindexer
+    bartio-beacon-80084:
+      chain_name: bera
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: stake
+        decimal: 6
+      packages:
+        - block
+        - voteindexer
+        # TODO ref; https://github.com/berachain/beacon-kit/blob/main/mod/node-api/handlers/beacon/routes.go
+        # - upgrade
+        # - uptime
+    bbn-test-5:
+      chain_name: babylon
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: ubbn
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    bitcanna-1:
+      chain_name: bitcanna
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ubcna
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    bitsong-2b:
+      chain_name: bitsong
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ubtsg
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    canto_7700-1:
+      chain_name: canto
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: acanto
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    cataclysm-1:
+      chain_name: nibiru
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: unibi
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - oracle
+        - voteindexer
+    celestia:
+      chain_name: celestia
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: utia
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    # NOTE: celestia bridge node hava same chain id in app node.
+    celestia-bridge:
+      chain_name: celestia
+      protocol_type: celestia
+      mainnet: true
+      support_asset:
+      packages:
+        - block
+    chihuahua-1:
+      chain_name: chihuahua
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uhuahua
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    comdex-1:
+      chain_name: comdex
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ucmdx
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    constantine-3:
+      chain_name: archway
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: aconst
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    core-1:
+      chain_name: persistence
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uxprt
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    coreum-mainnet-1:
+      chain_name: coreum
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ucore
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    cosmoshub-4:
+      chain_name: cosmos
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uatom
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    cronosmainnet_25-1:
+      chain_name: cronos
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: basecro
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    cronosmainnet_28-1:
+      chain_name: cronos
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: basecro
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    crypto-org-chain-mainnet-1:
+      chain_name: crypto-org
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: basecro
+        decimal: 8
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    cudos-1:
+      chain_name: cudos
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: acudos
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    desmos-mainnet:
+      chain_name: desmos
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: udsm
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    dimension_37-1:
+      chain_name: xpla
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: axpla
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    dydx-mainnet-1:
+      chain_name: dydx
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: adydx
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+        - veindexer
+    dydx-testnet-4:
+      chain_name: dydx
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: adydx
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+        - veindexer
+    dymension_1100-1:
+      chain_name: dymension
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: adym
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    evmos_9000-4:
+      chain_name: evmos
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: aevmos
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    evmos_9001-2:
+      chain_name: evmos
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: aevmos
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    elys-1:
+      chain_name: elys
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uelys
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    fetchhub-4:
+      chain_name: fetchai
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: afet
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    finschia-2:
+      chain_name: finschia
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: cony
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    govgen-1:
+      chain_name: govgen
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ugovgen
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    grand-1:
+      chain_name: noble
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: ustake
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    gravity-bridge-3:
+      chain_name: gravity-bridge
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ugraviton
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - eventnonce
+        - voteindexer
+    humans_1089-1:
+      chain_name: humans
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: aheart
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    iliad-0:
+      chain_name: story
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: stake
+        decimal: 6
+      packages:
+        - block
+        - voteindexer
+    initiation-1:
+      chain_name: initia
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uinit
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+        - veindexer
+    initiation-2:
+      chain_name: initia
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uinit
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+        - veindexer
+    injective-1:
+      chain_name: injective
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: inj
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - eventnonce
+        - voteindexer
+    irishub-1:
+      chain_name: iris
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uiris
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    ixo-5:
+      chain_name: ixo
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uixo
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    juno-1:
+      chain_name: juno
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ujuno
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    kaon-1:
+      chain_name: kyve
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: ukyve
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    kava_2221-16000:
+      chain_name: kava
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: ukava
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    kava_2222-10:
+      chain_name: kava
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ukava
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    kichain-2:
+      chain_name: ki-chain
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uxki
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    kyve-1:
+      chain_name: kyve
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ukyve
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    laozi-mainnet:
+      chain_name: band
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uband
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - yoda
+        - voteindexer
+    lava-mainnet-1:
+      chain_name: lava
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ulava
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    likecoin-mainnet-2:
+      chain_name: likecoin
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: nanolike
+        decimal: 9
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    lum-network-1:
+      chain_name: lum
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ulum
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    mantle-1:
+      chain_name: asset-mantle
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: umntl
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    mantra-1:
+      chain_name: mantra
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uom
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+        - veindexer
+    mantra-dukong-1:
+      chain_name: mantra
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uom
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+        - veindexer
+    mantra-hongbai-1:
+      chain_name: mantra
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uom
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    milkyway:
+      chain_name: milkyway
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: umilk
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    mocha-4:
+      chain_name: celestia
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: utia
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    # NOTE: celestia bridge node hava same chain id in app node.
+    mocha-4-bridge:
+      chain_name: celestia
+      protocol_type: celestia
+      mainnet: false
+      support_asset:
+      packages:
+        - block
+    namada.5f5de2dd1b88cba30586420:
+      chain_name: namada
+      protocol_type: cosmos
+      mainnet: true
+      packages:
+        - block
+    neutron-1:
+      chain_name: neutron
+      protocol_type: cosmos
+      mainnet: true
+      consumer: true
+      support_asset:
+        denom: untrn
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+        - veindexer
+    nillion:
+      chain_name: nillion
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: unil
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    nillion-chain-testnet-1:
+      chain_name: nillion
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: unil
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    noble-1:
+      chain_name: noble
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ustake
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    nyx:
+      chain_name: nyx
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: unyx
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    odyssey-0:
+      chain_name: story
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: stake
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    omniflixhub-1:
+      chain_name: omniflix
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uflix
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    onomy-mainnet-1:
+      chain_name: onomy-protocol
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: anom
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    osmo-test-5:
+      chain_name: osmosis
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uosmo
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    osmosis-1:
+      chain_name: osmosis
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uosmo
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    pacific-1:
+      chain_name: sei
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: usei
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - oracle
+        - voteindexer
+    panacea-3:
+      chain_name: medibloc
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: umed
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    passage-2:
+      chain_name: passage
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: upasg
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    ignite_186-1:
+      chain_name: pell
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: apell
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    phoenix-1:
+      chain_name: terra
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uluna
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    pio-mainnet-1:
+      chain_name: provenance
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: nhash
+        decimal: 9
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    pion-1:
+      chain_name: neutron
+      protocol_type: cosmos
+      mainnet: false
+      consumer: true
+      support_asset:
+        denom: untrn
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+        - veindexer
+    provider:
+      chain_name: cosmos
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uatom
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    quasar-1:
+      chain_name: quasar
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uqsr
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    quasar-test-1:
+      chain_name: quasar
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uqsr
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    quicksilver-2:
+      chain_name: quicksilver
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uqck
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    regen-1:
+      chain_name: regen
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uregen
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    secret-4:
+      chain_name: secret
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uscrt
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    self-1:
+      chain_name: selfchain
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uslf
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    sentinelhub-2:
+      chain_name: sentinel
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: udvpn
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    shentu-2.2:
+      chain_name: shentu
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uctk
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    sommelier-3:
+      chain_name: sommelier
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: usomm
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - eventnonce
+        - voteindexer
+    ssc-1:
+      chain_name: saga
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: usaga
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    ssc-testnet-2:
+      chain_name: saga
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: utsaga
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    stafihub-1:
+      chain_name: stafi
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ufis
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    stargaze-1:
+      chain_name: stargaze
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: ustars
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    stride-1:
+      chain_name: stride
+      protocol_type: cosmos
+      mainnet: true
+      consumer: true
+      support_asset:
+        denom: ustrd
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    tabi_9788-2:
+      chain_name: tabi
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: atabi
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    teritori-1:
+      chain_name: teritori
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: utori
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    test-core-2:
+      chain_name: persistence
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uxprt
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    umee-1:
+      chain_name: umee
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uumee
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - oracle
+        - voteindexer
+    uni-6:
+      chain_name: juno
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: ujuno
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    union-testnet-8:
+      chain_name: union
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: muno
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    xion-mainnet-1:
+      chain_name: xion
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: uxion
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    xion-testnet-1:
+      chain_name: xion
+      protocol_type: cosmos
+      mainnet: false
+      support_asset:
+        denom: uxion
+        decimal: 6
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer
+    zetachain_7000-1:
+      chain_name: zeta
+      protocol_type: cosmos
+      mainnet: true
+      support_asset:
+        denom: azeta
+        decimal: 18
+      packages:
+        - block
+        - upgrade
+        - uptime
+        - voteindexer

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "cvms.fullname" . }}-test-connection"
+  labels:
+    {{- include "cvms.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  containers:
+    - name: wget-indexer
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "cvms.fullname" . }}:{{ .Values.indexer.service.port }}']
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+    - name: wget-exporter
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "cvms.fullname" . }}:{{ .Values.exporter.service.port }}']
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+  restartPolicy: Never

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,484 @@
+# Default values for cvms.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+imagePullSecrets: []
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+namespaceOverride: ""
+
+# For devents, testnets, localnet even if unsupported mainnets, Use custom_chains.yaml.example for CVMS
+# Edit custom chains at helm/files/custom_chains.yaml.example
+customChainsConfig:
+  enabled: false
+  name: "custom-chains-cm"
+  annotations: {}
+  extraLabels: {}
+
+cvmsConfig:
+  name: "cvms-cm"
+  annotations: {}
+  extraLabels: {}
+  # NOTE: Customize this variables by your needs
+  # 1. network mode:
+  #   ex) monikers: ['all']
+  #   des) This will enable network mode to monitor all validators status in the blockchain network
+  #
+  # 2. validator mode:
+  #   ex) monikers: ['Cosmostation1', 'Cosmostation2']
+  #   des) This will enable validator mode for whitelisted specific validators
+  # Example reference: https://github.com/cosmostation/cvms/blob/develop/docs/setup.md
+  monikers: []
+  chains: []
+  # - display_name: 'cosmos'
+  #   # NOTE: chain_id is a key for support_chains list. YOU SHOULD match correct CHAIN ID
+  #   chain_id: cosmoshub-4
+  #   # NOTE: these addresses will be used for balance usage tracking such as validator, broadcaster or something.
+  #   tracking_addresses:
+  #     - 'cosmos1clpqr4nrk4khgkxj78fcwwh6dl3uw4ep4tgu9q'
+  #   nodes:
+  #     # NOTE: currently grpc endpoint doesn't support ssl
+  #     - rpc: 'https://rpc-cosmos.endpoint.xyz'
+  #       api: 'https://lcd-cosmos.endpoint.xyz'
+  #       grpc: 'grpc-cosmos.endpoint.xyz:9090'
+
+indexer:
+  replicaCount: 1
+
+  image:
+    repository: cosmostation/cvms
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "latest"
+
+  command:
+    - /bin/cvms
+  args:
+    - start
+    - indexer
+    - --config=/var/lib/cvms/config.yaml
+    - --log-color-disable
+    - "false"
+    - --log-level
+    - "4"
+    - --port=9300
+
+  env:
+    DB_RETENTION_PERIOD: 1h
+
+  # -- Number of old deployment ReplicaSets to retain. The rest will be garbage collected.
+  revisionHistoryLimit: 2
+
+  podAnnotations: {}
+  # Do not change these keys that are already defined
+  # app.kubernetes.io/instance: 
+  # app.kubernetes.io/managed-by: 
+  # app.kubernetes.io/name:
+  # app.kubernetes.io/version:
+  # argocd.argoproj.io/instance:
+  # helm.sh/chart:
+  podLabels: {}
+    # app.kubernetes.io/name: 
+    # app.kubernetes.io/branch-of:
+
+  podSecurityContext:
+    enabled: false
+    yamlSyntax:
+      fsGroup: 2000
+
+  securityContext:
+    enabled: true
+    yamlSyntax:
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 9300
+
+  resources:
+    enabled: true
+    yamlSyntax:
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+  livenessProbe:
+    enabled: true
+    yamlSyntax:
+      httpGet:
+        path: /metrics
+        port: metrics
+  readinessProbe:
+    enabled: true
+    yamlSyntax:
+      httpGet:
+        path: /metrics
+        port: metrics
+
+  # Additional volumes on the output Deployment definition and also mounting configmap.
+  volumes:
+    - configMap:
+        items:
+          - key: support_chains.yaml
+            path: support_chains.yaml
+        name: support-chains-cm
+      name: support-chains-cm
+    - configMap:
+        items:
+          - key: config.yaml
+            path: config.yaml
+        name: cvms-cm
+      name: cvms-cm
+    - name: init-script
+      configMap:
+        name: postgresql-init-script
+        defaultMode: 0421
+
+  # Additional volumeMounts on the output Deployment definition and also mounting configmap.
+  volumeMounts:
+    - mountPath: /var/lib/cvms/docker/cvms/support_chains.yaml
+      name: support-chains-cm
+      readOnly: true
+      subPath: support_chains.yaml
+    - mountPath: /var/lib/cvms/config.yaml
+      name: cvms-cm
+      readOnly: true
+      subPath: config.yaml
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  ## Server metrics service configuration
+  metrics:
+    # -- Metrics service type
+    type: ClusterIP
+    # -- Metrics service clusterIP. `None` makes a "headless service" (no virtual IP)
+    clusterIP: ""
+    # -- Metrics service annotations
+    annotations: {}
+    # -- Metrics service labels
+    # Do not use these keys for labels: app.kubernetes.io/namespace and app.kubernetes.io/metrics-enabled
+    labels: {}
+    # -- Metrics service port
+    servicePort: 9300
+    # -- Metrics service port name
+    portName: http-metrics
+  serviceMonitor:
+    # -- Enable a prometheus ServiceMonitor
+    enabled: false
+    # -- Prometheus ServiceMonitor interval
+    interval: 15s
+    # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
+    scrapeTimeout: ""
+    # path to scrape metrics:
+    path: "/metrics"
+    # -- Prometheus [RelabelConfigs] to apply to samples before scraping
+    relabelings: []
+    # -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestion
+    metricRelabelings: []
+    # -- Prometheus ServiceMonitor selector
+    selector: {}
+      # prometheus: kube-prometheus
+
+    # -- Prometheus ServiceMonitor scheme
+    scheme: ""
+    # -- Prometheus ServiceMonitor tlsConfig
+    tlsConfig: {}
+    # -- Prometheus ServiceMonitor namespace
+    namespace: ""  # monitoring
+    # -- Prometheus ServiceMonitor labels
+    additionalLabels: {}
+    # -- Prometheus ServiceMonitor annotations
+    annotations: {}
+
+  initContainers:
+    enabled: true  # Set to false if you want to disable the init-schema container
+    containers:
+      - name: init-schema
+        image: docker.io/alpine:latest
+        imagePullPolicy: IfNotPresent
+        command:
+          - "/bin/sh"
+          - "-c"
+        args:
+          - apk add --no-cache curl jq postgresql-client; /scripts/init-schema.sh
+        volumeMounts:
+          - name: init-script
+            mountPath: /scripts
+            readOnly: false
+
+exporter:
+  replicaCount: 1
+
+  image:
+    repository: cosmostation/cvms
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "latest"
+
+  command:
+    - /bin/cvms
+  args:
+    - start
+    - exporter
+    - --config=/var/lib/cvms/config.yaml
+    - --log-color-disable
+    - "false"
+    - --log-level
+    - "4"
+    - --port=9200
+
+  env: {}
+    # DB_HOST: localhost
+    # DB_PORT: "5432"
+
+  # -- Number of old deployment ReplicaSets to retain. The rest will be garbage collected.
+  revisionHistoryLimit: 2
+
+  podAnnotations: {}
+  # Do not change these keys that are already defined
+  # app.kubernetes.io/instance: 
+  # app.kubernetes.io/managed-by: 
+  # app.kubernetes.io/name:
+  # app.kubernetes.io/version:
+  # argocd.argoproj.io/instance:
+  # helm.sh/chart:
+  podLabels: {}
+    # app.kubernetes.io/name: 
+    # app.kubernetes.io/branch-of:
+
+  podSecurityContext:
+    enabled: false
+    yamlSyntax:
+      fsGroup: 2000
+
+  securityContext:
+    enabled: true
+    yamlSyntax:
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 9200
+
+  resources:
+    enabled: true
+    yamlSyntax:
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+  livenessProbe:
+    enabled: true
+    yamlSyntax:
+      httpGet:
+        path: /metrics
+        port: metrics
+  readinessProbe:
+    enabled: true
+    yamlSyntax:
+      httpGet:
+        path: /metrics
+        port: metrics
+
+  # Additional volumes on the output Deployment definition and also mounting configmap.
+  volumes:
+    - configMap:
+        items:
+          - key: support_chains.yaml
+            path: support_chains.yaml
+        name: support-chains-cm
+      name: support-chains-cm
+    - configMap:
+        items:
+          - key: config.yaml
+            path: config.yaml
+        name: cvms-cm
+      name: cvms-cm
+
+  # Additional volumeMounts on the output Deployment definition and also mounting configmap.
+  volumeMounts:
+    - mountPath: /var/lib/cvms/docker/cvms/support_chains.yaml
+      name: support-chains-cm
+      readOnly: true
+      subPath: support_chains.yaml
+    - mountPath: /var/lib/cvms/config.yaml
+      name: cvms-cm
+      readOnly: true
+      subPath: config.yaml
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  ## Server metrics service configuration
+  metrics:
+    # -- Metrics service type
+    type: ClusterIP
+    # -- Metrics service clusterIP. `None` makes a "headless service" (no virtual IP)
+    clusterIP: ""
+    # -- Metrics service annotations
+    annotations: {}
+    # -- Metrics service labels
+    # Do not use these keys for labels: app.kubernetes.io/namespace and app.kubernetes.io/metrics-enabled
+    labels: {}
+    # -- Metrics service port
+    servicePort: 9200
+    # -- Metrics service port name
+    portName: http-metrics
+  serviceMonitor:
+    # -- Enable a prometheus ServiceMonitor
+    enabled: false
+    # -- Prometheus ServiceMonitor interval
+    interval: 15s
+    # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
+    scrapeTimeout: ""
+    # path to scrape metrics:
+    path: "/metrics"
+    # -- Prometheus [RelabelConfigs] to apply to samples before scraping
+    relabelings: []
+    # -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestion
+    metricRelabelings: []
+    # -- Prometheus ServiceMonitor selector
+    selector: {}
+      # prometheus: kube-prometheus
+
+    # -- Prometheus ServiceMonitor scheme
+    scheme: ""
+    # -- Prometheus ServiceMonitor tlsConfig
+    tlsConfig: {}
+    # -- Prometheus ServiceMonitor namespace
+    namespace: ""  # monitoring
+    # -- Prometheus ServiceMonitor labels
+    additionalLabels: {}
+    # -- Prometheus ServiceMonitor annotations
+    annotations: {}
+    #  Prometheus rules
+    #  Some examples from https://github.com/cosmostation/cvms/tree/release/docker/prometheus/rules
+    #  View alert rules at helm/files
+    prometheusRule:
+      enabled: false
+      additionalLabels: {}
+      annotations: {}
+      namespace: ""
+      ruleSets:
+        - name: axelar-evm
+          enabled: true
+        - name: balance # change addresses of balance rules
+          enabled: true
+        - name: block
+          enabled: true
+        - name: consensus-vote
+          enabled: true
+        - name: eventnonce
+          enabled: true
+        - name: extension-vote
+          enabled: false
+        - name: oracle
+          enabled: true
+        - name: root
+          enabled: true
+        - name: upgrade
+          enabled: true
+        - name: uptime
+          enabled: false
+        - name: yoda
+          enabled: true
+      rules: []
+        # - alert: IncreasingMissCounterOver30%During1h
+        #   expr: |
+        #     # 30mins ago, the validator is unjailed. but got jailed 
+        #     cvms_uptime_jailed - cvms_uptime_jailed offset 30m > 0 and (cvms_uptime_jailed offset 30m == 0)
+        #   labels:
+        #     severity: critical
+        #   annotations:
+        #     summary: The validator is jailed now in {{ $labels.chain_id }}
+
+## PostgreSQL chart configuration
+## ref: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+## @param postgresql.enabled Switch to enable or disable the PostgreSQL helm chart
+## @param postgresql.auth.postgresPassword Password for the "postgres" admin user
+## @param postgresql.auth.username Name for a custom user to create
+## @param postgresql.auth.password Password for the custom user to create
+## @param postgresql.auth.database Name for a custom database to create
+## @param postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials
+## @param postgresql.auth.usePasswordFiles Mount credentials as a files instead of using an environment variable
+## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
+##
+postgresql:
+  enabled: true
+  auth:
+    username: cvms
+    password: "mysecretpassword"
+    database: cvms
+    postgresPassword: ""
+  architecture: standalone
+  primary:
+    ## PostgreSQL Primary resource requests and limits
+    ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    ## @param postgresql.primary.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if primary.resources is set (primary.resources is recommended for production).
+    ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+    ##
+    resourcesPreset: "nano"
+    ## @param postgresql.primary.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+    ## Example:
+    ## resources:
+    ##   requests:
+    ##     cpu: 2
+    ##     memory: 512Mi
+    ##   limits:
+    ##     cpu: 3
+    ##     memory: 1024Mi
+    ##
+    resources: {}
+    persistence:
+      storageClass: ""
+      size: 500Mi
+  ## External PostgreSQL configuration
+  ## All of these values are only used when postgresql.enabled is set to false
+  ## @param postgresql.external.host Database host
+  ## @param postgresql.external.port Database port number
+  ## @param postgresql.external.user Non-root username for Kong
+  ## @param postgresql.external.password Password for the non-root username for Kong
+  ## @param postgresql.external.database Kong database name
+  ## @param postgresql.external.existingSecret Name of an existing secret resource containing the database credentials
+  ## @param postgresql.external.existingSecretPasswordKey Name of an existing secret key containing the database credentials
+  ##
+  external:
+    host: ""
+    port: 5432
+    user: cvms
+    password: ""
+    database: cvms


### PR DESCRIPTION
## PR(Pull Request) Overview

This PR adds a Helm chart for the Cosmos Validator Monitoring Service (CVMS) to the repository. The Helm chart allows for easy deployment and management of CVMS on Kubernetes.

#### Changes

- [x] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update

#### Description of Changes

- Added two dependencies of Bitnami Postgresql as subchart and Bitnami common.
- Added an init container for indexer service to apply schema migration in postgresql, by downloading schemas of release branch dynamically whenever they update.
- Added serviceMonitor config for indexer and exporter service, and also prometheusRule for adding alert rules of (cvms/helm/files) into Prometheus operator.


#### Testing Method

Explain how to test the changes step by step:
1. Navigate to the `helm` directory.
2. Change the values.yaml file based on your desired configuration, the main config of cvms should be modified by cvmsConfig.monikers and cvmsConfig.chains.
3. Enable the serviceMonitor of indexer and exporter service.
4. Run `helm install my-release cvms/helm` to install the Helm chart.
5. Verify that the CVMS pods are running and healthy using `kubectl get pods`.
6. If you want to add metrics endpoints manually, check the services using `kubectl get svc`.