### PR TITLE
Feature: babylon btc lightclient package

### DIFF
--- a/docker/cvms/support_chains.yaml
+++ b/docker/cvms/support_chains.yaml
@@ -178,6 +178,7 @@ bbn-test-5:
     - uptime
     - voteindexer
     - babylon_checkpoint
+    - babylon-btc-lightclient
     - finality-provider-indexer
     - finality-provider-uptime
 bitcanna-1:

--- a/docker/postgres/schema/02-init-babylon_btc_lightclient.sql
+++ b/docker/postgres/schema/02-init-babylon_btc_lightclient.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "public"."babylon_btc_lightclient" (
+        "id" BIGINT GENERATED ALWAYS AS IDENTITY,
+        "chain_info_id" INT NOT NULL,
+        "height" BIGINT NOT NULL,
+        "reporter_id" INT NOT NULL,
+        "header_count" SMALLINT NOT NULL, 
+        "btc_headers" TEXT NOT NUll,
+        PRIMARY KEY ("id", "chain_info_id"),
+        CONSTRAINT fk_chain_info_id FOREIGN KEY (chain_info_id) REFERENCES meta.chain_info (id) ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT fk_reporter_id FOREIGN KEY (reporter_id, chain_info_id) REFERENCES meta.validator_info (id, chain_info_id),
+        CONSTRAINT uniq_babylon_btc_lightclient_by_height UNIQUE ("chain_info_id","height","reporter_id")
+    )
+PARTITION BY
+    LIST ("chain_info_id");
+
+CREATE INDEX IF NOT EXISTS babylon_btc_lightclient_idx_01 ON public.babylon_btc_lightclient (height);
+CREATE INDEX IF NOT EXISTS babylon_btc_lightclient_idx_02 ON public.babylon_btc_lightclient (reporter_id, height);
+CREATE INDEX IF NOT EXISTS babylon_btc_lightclient_idx_03 ON public.babylon_btc_lightclient USING btree (chain_info_id, reporter_id, height desc);

--- a/internal/app/indexer/select.go
+++ b/internal/app/indexer/select.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cosmostation/cvms/internal/common"
 	"github.com/cosmostation/cvms/internal/helper"
 	"github.com/cosmostation/cvms/internal/helper/config"
+	btclcindexer "github.com/cosmostation/cvms/internal/packages/babylon-btc-lightclient/indexer"
 	bcindexer "github.com/cosmostation/cvms/internal/packages/consensus/babylon-checkpoint/indexer"
 	veindexer "github.com/cosmostation/cvms/internal/packages/consensus/veindexer/indexer"
 	voteindexer "github.com/cosmostation/cvms/internal/packages/consensus/voteindexer/indexer"
@@ -116,6 +117,18 @@ func selectPackage(
 			return errors.Wrap(err, common.ErrFailedToBuildPackager)
 		}
 		return fpindexer.Start()
+	case pkg == "babylon-btc-lightclient":
+		endpoints := common.Endpoints{RPCs: validRPCs, CheckRPC: true, APIs: validAPIs, CheckAPI: true}
+		p, err := common.NewPackager(m, f, l, mainnet, chainID, chainName, pkg, protocolType, cc, endpoints, monikers...)
+		if err != nil {
+			return errors.Wrap(err, common.ErrFailedToBuildPackager)
+		}
+		p.SetIndexerDB(idb)
+		btclcindexer, err := btclcindexer.NewBTCLightClientIndexer(*p)
+		if err != nil {
+			return errors.Wrap(err, common.ErrFailedToBuildPackager)
+		}
+		return btclcindexer.Start()
 	}
 
 	return common.ErrUnSupportedPackage

--- a/internal/common/api/api.go
+++ b/internal/common/api/api.go
@@ -291,8 +291,8 @@ func GetConsumerChainHRP(c common.CommonClient) (string, error) {
 
 // query a new block to find missed validators index
 func GetBlockResults(c common.CommonClient, height int64) (
-	[]types.BlockEvent,
-	[]types.BlockEvent,
+	/* txs events */ []types.BlockEvent,
+	/* block events */ []types.BlockEvent,
 	/* unexpected error */ error,
 ) {
 

--- a/internal/common/api/babylon.go
+++ b/internal/common/api/babylon.go
@@ -193,3 +193,25 @@ func GetBabylonFinalityProviderParams(c common.CommonClient) (float64, float64, 
 
 	return signedBlocksWindow, minSignedPerWindow, nil
 }
+
+func GetBabylonBTCLightClientParams(c common.CommonClient) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
+	defer cancel()
+
+	requester := c.APIClient.R().SetContext(ctx)
+	resp, err := requester.Get(types.BabylonBTCLightClientParamsQueryPath)
+	if err != nil {
+		return nil, errors.Errorf("rpc call is failed from %s: %s", resp.Request.URL, err)
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return nil, errors.Errorf("stanage status code from %s: [%d]", resp.Request.URL, resp.StatusCode())
+	}
+
+	allowList, err := parser.ParserBTCLightClientParams(resp.Body())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return allowList, nil
+}

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -178,7 +178,6 @@ func initSchemaFromDir(db *bun.DB, dir string) error {
 		if _, err := db.Exec(string(sqlBytes)); err != nil {
 			return fmt.Errorf("failed to execute schema file %s: %w", file, err)
 		}
-		log.Printf("Executed schema file: %s", file)
 	}
 	return nil
 }

--- a/internal/common/packager.go
+++ b/internal/common/packager.go
@@ -15,6 +15,7 @@ var (
 		"veindexer",
 		"babylon_checkpoint",
 		"finality-provider-indexer",
+		"babylon-btc-lightclient",
 	}
 
 	ExporterPackages = []string{

--- a/internal/common/parser/babylon.go
+++ b/internal/common/parser/babylon.go
@@ -71,3 +71,13 @@ func ParserFinalityParams(resp []byte) (float64, float64, error) {
 
 	return signedBlocksWindow, minSignedPerWindow, nil
 }
+
+func ParserBTCLightClientParams(resp []byte) ([]string, error) {
+	var result types.BabylonBTCLightClientParams
+	err := json.Unmarshal(resp, &result)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return result.Params.InsertHeadersAllowList, nil
+}

--- a/internal/common/types/babylon.go
+++ b/internal/common/types/babylon.go
@@ -79,3 +79,11 @@ type FinalityProvidersResponse struct {
 var BabylonFinalityVotesQueryPath = func(height int64) string {
 	return fmt.Sprintf("/babylon/finality/v1/votes/%d", height)
 }
+
+var BabylonBTCLightClientParamsQueryPath string = "/babylon/btclightclient/v1/params"
+
+type BabylonBTCLightClientParams struct {
+	Params struct {
+		InsertHeadersAllowList []string `json:"insert_headers_allow_list"`
+	} `json:"params"`
+}

--- a/internal/packages/babylon-btc-lightclient/indexer/babylon.go
+++ b/internal/packages/babylon-btc-lightclient/indexer/babylon.go
@@ -1,0 +1,142 @@
+package indexer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cosmostation/cvms/internal/common/types"
+	"github.com/pkg/errors"
+)
+
+// FilterEvents filters events of type "babylon.btclightclient.v1.EventBTCHeaderInserted"
+// and events of type "message" where an attribute with key "action" has the value "/babylon.btclightclient.v1.MsgInsertHeaders"
+// case1 ) https://www.mintscan.io/babylon-testnet/tx/821DC4CD513A988BBFFE9DF7717593684798F8DF12D8E9A2373C98217A8FA806?sector=logs
+// case2 ) https://www.mintscan.io/babylon-testnet/tx/A2F002F01AEFC23B01171D438950AD93B5418230DFAD56A60A2F54983ADB2F83?sector=logs
+const (
+	InsertHeadersTypeURL = "/babylon.btclightclient.v1.MsgInsertHeaders"
+	BTCRollForwardEvent  = "babylon.btclightclient.v1.EventBTCRollForward"
+	BTCRollbackEvent     = "babylon.btclightclient.v1.EventBTCRollBack"
+)
+
+// TODO: add return err
+func filterBTCLightClientEvents(events []types.BlockEvent) ([]BTCInsertEvent, error) {
+	bieList := make([]BTCInsertEvent, 0)
+	btcHeaderList := make([]BTCHeader, 0)
+	reporter := ""
+	found := false
+
+	for idx, e := range events {
+		if e.TypeName == "message" {
+			for _, attr := range e.Attributes {
+				if attr.Key == "action" && attr.Value == InsertHeadersTypeURL {
+					// if already found, we need reinit for new reporter
+					if found {
+						btcHeaderList = make([]BTCHeader, 0)
+						reporter = ""
+					}
+
+					found = true
+				}
+
+				if attr.Key == "sender" && found {
+					reporter = attr.Value
+				}
+			}
+		}
+
+		if found {
+			if (e.TypeName == BTCRollForwardEvent) || (e.TypeName == BTCRollbackEvent) {
+				for _, attr := range e.Attributes {
+					if attr.Key == "header" {
+						btcHeader, err := ParseBTCHeader(attr.Value)
+						if err != nil {
+							return nil, errors.Wrap(err, "failed to parse btc header event")
+						}
+						btcHeader.EventType = ExtractEventType(e.TypeName)
+						btcHeaderList = append(btcHeaderList, btcHeader)
+					}
+				}
+			}
+		}
+
+		if idx == (len(events) - 1) {
+			// finally add
+			bieList = append(bieList, BTCInsertEvent{
+				ReporterAddress: reporter,
+				BTCHeaders:      btcHeaderList,
+			})
+		}
+	}
+
+	// not found anyone return nil
+	if !found {
+		return nil, nil
+	}
+
+	return bieList, nil
+}
+
+type BTCInsertEventSummary struct {
+	skip            bool
+	BlockHeight     int64
+	BTCInsertEvents []BTCInsertEvent
+}
+
+type BTCInsertEvent struct {
+	ReporterAddress string
+	BTCHeaders      []BTCHeader
+}
+
+// ToStringSlice converts BTCHeaders to a slice of strings
+func (e BTCInsertEvent) ToHeadersStringSlice() string {
+	var headers []string
+	for _, header := range e.BTCHeaders {
+		headers = append(headers, header.String())
+	}
+
+	return strings.Join(headers, "\n")
+}
+
+type BTCHeader struct {
+	EventType string `json:"event_type"`
+	Header    string `json:"header"`
+	Hash      string `json:"hash"`
+	Height    int64  `json:"height"`
+	Work      string `json:"work"`
+}
+
+// String method for BTCInsertEvent
+func (h BTCHeader) String() string {
+	return fmt.Sprintf("EventType: %s, Header: %s, Hash: %s, Height: %d, Work: %s",
+		h.EventType, h.Header, h.Hash, h.Height, h.Work)
+}
+
+// Convert Go struct to JSON
+func (h BTCHeader) MustMarshalJSON() []byte {
+	jsonData, err := json.Marshal(h)
+	if err != nil {
+		return []byte("unexpected")
+	}
+
+	return jsonData
+}
+
+// ParseBTCHeader parses the "value" field into BTCHeader
+func ParseBTCHeader(value string) (BTCHeader, error) {
+	var btcHeader BTCHeader
+	err := json.Unmarshal([]byte(value), &btcHeader)
+	if err != nil {
+		return BTCHeader{}, err
+	}
+	return btcHeader, nil
+}
+
+// ExtractEventType extracts the event type name from a fully qualified event type string
+func ExtractEventType(eventType string) string {
+	parts := strings.Split(eventType, ".")
+	if len(parts) == 0 {
+		return eventType // Return original string if split fails
+	}
+	return parts[len(parts)-1]
+}

--- a/internal/packages/babylon-btc-lightclient/indexer/indexer.go
+++ b/internal/packages/babylon-btc-lightclient/indexer/indexer.go
@@ -4,64 +4,58 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/pkg/errors"
-
+	"github.com/cosmostation/cvms/internal/common"
+	indexertypes "github.com/cosmostation/cvms/internal/common/indexer/types"
 	"github.com/cosmostation/cvms/internal/helper"
 	"github.com/cosmostation/cvms/internal/helper/db"
 	"github.com/cosmostation/cvms/internal/helper/healthcheck"
-
-	"github.com/cosmostation/cvms/internal/common"
-	indexertypes "github.com/cosmostation/cvms/internal/common/indexer/types"
-	"github.com/cosmostation/cvms/internal/packages/consensus/babylon-checkpoint/repository"
+	"github.com/cosmostation/cvms/internal/packages/babylon-btc-lightclient/repository"
+	"github.com/pkg/errors"
 )
 
-var subsystem = "babylon_checkpoint"
+var (
+	subsystem                 = "babylon_btc_lightclient"
+	_         common.IIndexer = (*BTCLightClientIndexer)(nil)
+)
 
-type CheckpointIndexer struct {
+type BTCLightClientIndexer struct {
 	*common.Indexer
-	repo                repository.CheckpointIndexerRepository
+	repository.BTCLightClientIndexerRepository
 	earliestBlockHeight int64
-	lastDBEpoch         int64
 }
 
-var _ common.IIndexer = (*CheckpointIndexer)(nil)
-
-func NewCheckpointIndexer(p common.Packager) (*CheckpointIndexer, error) {
+func NewBTCLightClientIndexer(p common.Packager) (*BTCLightClientIndexer, error) {
 	status := helper.GetOnChainStatus(p.RPCs, p.ProtocolType)
 	if status.ChainID == "" {
-		return nil, errors.Errorf("failed to create a new checkpoint indexer: %v", status)
+		return nil, errors.Errorf("failed to create a new indexer: %v", status)
 	}
 	indexer := common.NewIndexer(p, p.Package, status.ChainID)
-	repo := repository.NewRepository(*p.IndexerDB, indexertypes.SQLQueryMaxDuration)
+	repo := repository.NewRepository(*p.IndexerDB, subsystem, indexertypes.SQLQueryMaxDuration)
 	indexer.Lh = indexertypes.LatestHeightCache{LatestHeight: status.BlockHeight}
-	return &CheckpointIndexer{indexer, repo, status.EarliestBlockHeight, 0}, nil
+	return &BTCLightClientIndexer{indexer, repo, status.EarliestBlockHeight}, nil
 }
 
-func (idx *CheckpointIndexer) Start() error {
+func (idx *BTCLightClientIndexer) Start() error {
 	err := idx.InitChainInfoID()
 	if err != nil {
 		return errors.Wrap(err, "failed to init chain_info_id")
 	}
 
-	alreadyInit, err := idx.repo.CheckIndexpoinerAlreadyInitialized(repository.IndexName, idx.ChainInfoID)
+	alreadyInit, err := idx.CheckIndexpoinerAlreadyInitialized(idx.IndexName, idx.ChainInfoID)
 	if err != nil {
 		return errors.Wrap(err, "failed to check init tables")
 	}
 	if !alreadyInit {
 		idx.Warnf("it's not initialized in the database, so that this package will initalize at %d as a init index point", idx.Lh.LatestHeight)
-		idx.repo.InitPartitionTablesByChainInfoID(repository.IndexName, idx.ChainID, idx.earliestBlockHeight)
+		// idx.InitPartitionTablesByChainInfoID(idx.IndexName, idx.ChainID, idx.Lh.LatestHeight)
+		idx.InitPartitionTablesByChainInfoID(idx.IndexName, idx.ChainID, idx.earliestBlockHeight)
+		idx.CreateValidatorInfoPartitionTableByChainID(idx.ChainID)
 	}
 
 	// get last index pointer, index pointer is always initalize if not exist
-	initIndexPointer, err := idx.repo.GetLastIndexPointerByIndexTableName(repository.IndexName, idx.ChainInfoID)
+	initIndexPointer, err := idx.GetLastIndexPointerByIndexTableName(idx.IndexName, idx.ChainInfoID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get last index pointer")
-	}
-
-	// get last epoch and save into indexer struct
-	lastDBEpoch, err := idx.repo.GetLastEpoch()
-	if err != nil {
-		return errors.WithStack(err)
 	}
 
 	err = idx.FetchValidatorInfoList()
@@ -69,17 +63,21 @@ func (idx *CheckpointIndexer) Start() error {
 		return errors.Wrap(err, "failed to fetch validator_info list")
 	}
 
-	idx.Infof("loaded last db epoch: %d, index pointer: %d, loaded validator id map: %d", lastDBEpoch, initIndexPointer.Pointer, len(idx.Vim))
+	idx.Infof("loaded index pointer(last saved height): %d", initIndexPointer.Pointer)
+	idx.Infof("initial vim length: %d for %s chain", len(idx.Vim), idx.ChainID)
 
 	// init indexer metrics
 	idx.initLabelsAndMetrics()
-
-	// NOTE: no need to sync lastest height in babylon checkpoint indexer
-	// go fetch new height in loop, it must be after init metrics
 	// go idx.FetchLatestHeight()
-
-	// loop
-	go idx.Loop(lastDBEpoch)
+	go idx.Loop(initIndexPointer.Pointer)
+	// loop update recent miss counter metrics
+	// go func() {
+	// 	for {
+	// 		idx.Infoln("update recent miss counter metrics and sleep 5s sec...")
+	// 		idx.updateRecentMissCounterMetric()
+	// 		time.Sleep(time.Second * 5)
+	// 	}
+	// }()
 	// loop partion table time retention by env parameter
 	go func() {
 		if idx.RetentionPeriod == db.PersistenceMode {
@@ -88,14 +86,14 @@ func (idx *CheckpointIndexer) Start() error {
 		}
 		for {
 			idx.Infof("for time retention, delete old records over %s and sleep %s", idx.RetentionPeriod, indexertypes.RetentionQuerySleepDuration)
-			idx.repo.DeleteOldValidatorExtensionVoteList(idx.ChainID, idx.RetentionPeriod)
+			idx.DeleteOldRecords(idx.ChainID, idx.RetentionPeriod)
 			time.Sleep(indexertypes.RetentionQuerySleepDuration)
 		}
 	}()
 	return nil
 }
 
-func (idx *CheckpointIndexer) Loop(indexPoint int64) {
+func (idx *BTCLightClientIndexer) Loop(indexPoint int64) {
 	isUnhealth := false
 	for {
 		// node health check
@@ -123,15 +121,14 @@ func (idx *CheckpointIndexer) Loop(indexPoint int64) {
 				continue
 			}
 		}
+
 		// trying to sync with new index pointer height
 		newIndexPointer, err := idx.batchSync(indexPoint)
 		if err != nil {
 			common.Health.With(idx.RootLabels).Set(0)
 			common.Ops.With(idx.RootLabels).Inc()
 			isUnhealth = true
-			idx.Errorf("failed to sync status in %d epoch: %s, it will be retried after sleep %s...",
-				indexPoint, err, indexertypes.AfterFailedRetryTimeout.String(),
-			)
+			idx.Errorf("failed to sync in %d height: %s, it will be retried after sleep %s...", indexPoint, err, indexertypes.AfterFailedFetchSleepDuration.String())
 			time.Sleep(indexertypes.AfterFailedRetryTimeout)
 			continue
 		}
@@ -142,14 +139,27 @@ func (idx *CheckpointIndexer) Loop(indexPoint int64) {
 		// update health and ops
 		common.Health.With(idx.RootLabels).Set(1)
 		common.Ops.With(idx.RootLabels).Inc()
+
+		// logging & sleep
+		if idx.Lh.LatestHeight > indexPoint {
+			// when node catching_up is true, sleep 100 milli sec
+			idx.WithField("catching_up", true).
+				Infof("latest height is %d but updated index pointer is %d ... remaining %d blocks", idx.Lh.LatestHeight, indexPoint, (idx.Lh.LatestHeight - indexPoint))
+			time.Sleep(indexertypes.CatchingUpSleepDuration)
+		} else {
+			// when node already catched up, sleep 5 sec
+			idx.WithField("catching_up", false).
+				Infof("updated index pointer to %d and sleep %s sec...", indexPoint, indexertypes.DefaultSleepDuration.String())
+			time.Sleep(indexertypes.DefaultSleepDuration)
+		}
 	}
 }
 
 // insert chain-info into chain_info table
-func (idx *CheckpointIndexer) InitChainInfoID() error {
+func (idx *BTCLightClientIndexer) InitChainInfoID() error {
 	isNewChain := false
 	var chainInfoID int64
-	chainInfoID, err := idx.repo.SelectChainInfoIDByChainID(idx.ChainID)
+	chainInfoID, err := idx.SelectChainInfoIDByChainID(idx.ChainID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			idx.Infof("this is new chain id: %s", idx.ChainID)
@@ -160,7 +170,7 @@ func (idx *CheckpointIndexer) InitChainInfoID() error {
 	}
 
 	if isNewChain {
-		chainInfoID, err = idx.repo.InsertChainInfo(idx.ChainName, idx.ChainID, idx.Mainnet)
+		chainInfoID, err = idx.InsertChainInfo(idx.ChainName, idx.ChainID, idx.Mainnet)
 		if err != nil {
 			return errors.Wrap(err, "failed to insert new chain_info_id by chain-id")
 		}
@@ -170,9 +180,9 @@ func (idx *CheckpointIndexer) InitChainInfoID() error {
 	return nil
 }
 
-func (idx *CheckpointIndexer) FetchValidatorInfoList() error {
+func (idx *BTCLightClientIndexer) FetchValidatorInfoList() error {
 	// get already saved validator-set list for mapping validators ids
-	validatorInfoList, err := idx.repo.GetValidatorInfoListByChainInfoID(idx.ChainInfoID)
+	validatorInfoList, err := idx.GetValidatorInfoListByChainInfoID(idx.ChainInfoID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get validator info list")
 	}

--- a/internal/packages/babylon-btc-lightclient/indexer/indexer.go
+++ b/internal/packages/babylon-btc-lightclient/indexer/indexer.go
@@ -35,6 +35,10 @@ func NewBTCLightClientIndexer(p common.Packager) (*BTCLightClientIndexer, error)
 	return &BTCLightClientIndexer{indexer, repo, status.EarliestBlockHeight}, nil
 }
 
+// NOTE: Babylon operates a Bitcoin light client that stores Bitcoin chain headers.
+// The light client is maintained up to date by the Vigilante (more specifically, the Vigilante Reporter), which tracks BTC state and submits the latest BTC headers to Babylon.
+// Ensuring that the BTC light client is up to date and can recover from Bitcoin re-orgs is very important for both the BTC Staking and the BTC Timestamping protocols.
+// The CVMS tool will index the Babylon node events BTCRollForward and BTCRollBack
 func (idx *BTCLightClientIndexer) Start() error {
 	err := idx.InitChainInfoID()
 	if err != nil {

--- a/internal/packages/babylon-btc-lightclient/indexer/indexer_test.go
+++ b/internal/packages/babylon-btc-lightclient/indexer/indexer_test.go
@@ -1,0 +1,111 @@
+package indexer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cosmostation/cvms/internal/common"
+	"github.com/cosmostation/cvms/internal/common/api"
+
+	"github.com/cosmostation/cvms/internal/helper/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	p = common.Packager{
+		ChainName:    "babylon",
+		ChainID:      "bbn-test-5",
+		ProtocolType: "cosmos",
+		Endpoints: common.Endpoints{
+			// RPCs: []string{"https://rpc-office.cosmostation.io/babylon-testnet"},
+			RPCs: []string{"https://babylon-testnet-rpc.polkachu.com"},
+			APIs: []string{"https://lcd-office.cosmostation.io/babylon-testnet"},
+		},
+		Logger: logger.GetTestLogger(),
+	}
+)
+
+func Test_1_GetBTCLightClientData(t *testing.T) {
+	app := common.NewCommonApp(p)
+	app.SetAPIEndPoint(p.Endpoints.APIs[0])
+	app.SetRPCEndPoint(p.Endpoints.RPCs[0])
+
+	_, err := api.GetBabylonBTCLightClientParams(app.CommonClient)
+	assert.NoError(t, err)
+
+	// 23921 : empty height
+	// 23828 : btc forward event height
+	// 23922 : btc roll back event height
+	testHeights := []int64{23921, 23828, 23922}
+
+	for _, h := range testHeights {
+		txsEvents, _, err := api.GetBlockResults(app.CommonClient, h)
+		assert.NoError(t, err)
+
+		// NOTE: bieList means btc insert events list
+		bieList, err := filterBTCLightClientEvents(txsEvents)
+		assert.NoError(t, err)
+
+		for _, bie := range bieList {
+			t.Logf("len header: %d", len(bie.BTCHeaders))
+			t.Logf("in %d height, got %s headers", h, bie.ToHeadersStringSlice())
+		}
+	}
+
+}
+
+func Test_2_BatchSync(t *testing.T) {
+	tempDBName := "temp"
+	indexerDB, err := common.NewTestLoaclIndexerDB(tempDBName)
+	p.SetIndexerDB(indexerDB)
+	p.IsConsumerChain = false
+	assert.NoError(t, err)
+
+	idx, err := NewBTCLightClientIndexer(p)
+	assert.NoError(t, err)
+
+	err = idx.InitChainInfoID()
+	assert.NoError(t, err)
+
+	err = idx.InitPartitionTablesByChainInfoID(idx.IndexName, idx.ChainID, 100)
+	assert.NoError(t, err)
+
+	err = idx.FetchValidatorInfoList()
+	assert.NoError(t, err)
+
+	newIndexPointer, err := idx.batchSync(23920)
+	assert.NoError(t, err)
+	t.Logf("new index point: %d", newIndexPointer)
+}
+
+func Test_3_Start(t *testing.T) {
+	waitingDuration := 60 * time.Second
+	// Step 1: Set up the database
+	tempDBName := "temp"
+	indexerDB, err := common.NewTestLoaclIndexerDB(tempDBName)
+	assert.NoError(t, err)
+
+	p.SetIndexerDB(indexerDB)
+	p.SetRetentionTime("1h")
+	p.IsConsumerChain = false
+
+	// Step 2: Initialize the CheckpointIndexer
+	idx, err := NewBTCLightClientIndexer(p)
+	assert.NoError(t, err)
+
+	// Modify Start() to accept a callback for testing purposes
+	err = idx.Start()
+	assert.NoError(t, err)
+
+	// Step 4: Wait for the goroutine to finish
+	done := make(chan bool)
+
+	go func() {
+		// Simulate some work
+		time.Sleep(waitingDuration)
+		done <- true
+	}()
+
+	<-done
+	t.Log("Goroutine finished work")
+}

--- a/internal/packages/babylon-btc-lightclient/indexer/metrics.go
+++ b/internal/packages/babylon-btc-lightclient/indexer/metrics.go
@@ -1,0 +1,36 @@
+package indexer
+
+import (
+	"github.com/cosmostation/cvms/internal/common"
+	"github.com/cosmostation/cvms/internal/common/api"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func (idx *BTCLightClientIndexer) initLabelsAndMetrics() {
+	epochMetric := idx.Factory.NewGauge(prometheus.GaugeOpts{
+		Namespace:   common.Namespace,
+		Subsystem:   subsystem,
+		Name:        common.IndexPointerEpochMetricName,
+		ConstLabels: idx.PackageLabels,
+	})
+	idx.MetricsMap[common.IndexPointerEpochMetricName] = epochMetric
+
+	timestampMetric := idx.Factory.NewGauge(prometheus.GaugeOpts{
+		Namespace:   common.Namespace,
+		Subsystem:   subsystem,
+		Name:        common.IndexPointerBlockTimestampMetricName,
+		ConstLabels: idx.PackageLabels,
+	})
+	idx.MetricsMap[common.IndexPointerBlockTimestampMetricName] = timestampMetric
+}
+
+func (idx *BTCLightClientIndexer) updatePrometheusMetrics(indexPointer int64) {
+	idx.MetricsMap[common.IndexPointerEpochMetricName].Set(float64(indexPointer))
+	_, timestamp, _, _, _, _, err := api.GetBlock(idx.CommonClient, indexPointer)
+	if err != nil {
+		idx.Errorf("failed to get block %d: %s", indexPointer, err)
+		return
+	}
+	idx.MetricsMap[common.IndexPointerBlockTimestampMetricName].Set((float64(timestamp.Unix())))
+	idx.Debugf("update prometheus metrics %d height", indexPointer)
+}

--- a/internal/packages/babylon-btc-lightclient/indexer/sync.go
+++ b/internal/packages/babylon-btc-lightclient/indexer/sync.go
@@ -1,0 +1,183 @@
+package indexer
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cosmostation/cvms/internal/common/api"
+	indexermodel "github.com/cosmostation/cvms/internal/common/indexer/model"
+	indexertypes "github.com/cosmostation/cvms/internal/common/indexer/types"
+	"github.com/cosmostation/cvms/internal/helper"
+
+	"github.com/cosmostation/cvms/internal/packages/babylon-btc-lightclient/model"
+	"github.com/pkg/errors"
+)
+
+func (idx *BTCLightClientIndexer) batchSync(lastIndexPoint int64) (
+	/* new index pointer */ int64,
+	/* error */ error,
+) {
+	if lastIndexPoint >= idx.Lh.LatestHeight {
+		idx.Infof("current height is %d and latest height is %d both of them are same, so it'll skip the logic", lastIndexPoint, idx.Lh.LatestHeight)
+		return lastIndexPoint, nil
+	}
+
+	// set starntHeight and endHeight for batch sync
+	startHeight := (lastIndexPoint + 1)
+	endHeight := idx.Lh.LatestHeight
+
+	// set limit at end-height in this batch sync logic
+	if (idx.Lh.LatestHeight - startHeight) > indexertypes.BatchSyncLimit {
+		endHeight = startHeight + indexertypes.BatchSyncLimit
+		idx.Debugf("by batch sync limit, end height will change to %d", endHeight)
+	}
+
+	// init channel and waitgroup for go-routine
+	ch := make(chan helper.Result)
+	wg := sync.WaitGroup{}
+	bieSummaryList := make(map[int64]BTCInsertEventSummary, 0)
+
+	// start to call block results
+	for h := startHeight; h <= endHeight; h++ {
+		wg.Add(1)
+		height := h
+
+		go func(ch chan helper.Result) {
+			defer helper.HandleOutOfNilResponse(idx.Entry)
+			defer wg.Done()
+
+			txsEvents, _, err := api.GetBlockResults(idx.CommonClient, height)
+			if err != nil {
+				idx.Errorf("failed to call at %d height data, %s", height, err)
+				ch <- helper.Result{Item: nil, Success: false}
+				return
+			}
+
+			// NOTE: bieList means btc insert events list
+			bieList, err := filterBTCLightClientEvents(txsEvents)
+			if err != nil {
+				idx.Errorf("failed to call at %d height data, %s", height, err)
+				ch <- helper.Result{Item: nil, Success: false}
+				return
+			}
+
+			// if there is no btc insert event in the block, just skip this height to index
+			if len(bieList) == 0 {
+				ch <- helper.Result{
+					Item:    BTCInsertEventSummary{true, height, bieList},
+					Success: true,
+				}
+			}
+
+			ch <- helper.Result{
+				Item:    BTCInsertEventSummary{false, height, bieList},
+				Success: true,
+			}
+		}(ch)
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// close channel
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	// collect block summary data into block summary list
+	errorCount := 0
+	for r := range ch {
+		if r.Success {
+			item := r.Item.(BTCInsertEventSummary)
+			bieSummaryList[item.BlockHeight] = item
+			continue
+		}
+		errorCount++
+	}
+
+	// check error count
+	if errorCount > 0 {
+		return lastIndexPoint, errors.Errorf("failed to collect batch block data, total errors: %d", errorCount)
+	}
+
+	// if there are new hex address in current block, collect their validator hex address to save in database
+	isNewReporter := false
+	newRepoterInfoList := make([]indexermodel.ValidatorInfo, 0)
+	for _, bie := range bieSummaryList {
+		if bie.skip {
+			continue
+		}
+
+		// check reporter address
+		for _, e := range bie.BTCInsertEvents {
+			_, exist := idx.Vim[e.ReporterAddress]
+			if !exist {
+				idx.Debugf("the reporter %s address isn't in current validator info table, the address will be added into the meta table", e.ReporterAddress)
+				newRepoterInfoList = append(newRepoterInfoList, indexermodel.ValidatorInfo{
+					ChainInfoID:     idx.ChainInfoID,
+					HexAddress:      e.ReporterAddress[:40],
+					OperatorAddress: e.ReporterAddress,
+					Moniker:         "Babylon Vigilante Repoter",
+				})
+				isNewReporter = true
+			}
+		}
+	}
+
+	// this logic will be progressed only when there are new tendermint validators in this block
+	if isNewReporter {
+		idx.Debugf("insert new vigilante reporters: %d", len(newRepoterInfoList))
+		err := idx.InsertValidatorInfoList(newRepoterInfoList)
+		if err != nil {
+			// NOTE: fetch again validator_info list, actually already inserted the list by other indexer service
+			idx.FetchValidatorInfoList()
+			return lastIndexPoint, errors.Wrapf(err, "failed to insert new reporter info list: %v", newRepoterInfoList)
+		}
+
+		// get already saved tendermint validator list for mapping validators ids
+		repoterInfoList, err := idx.GetValidatorInfoListByChainInfoID(idx.ChainInfoID)
+		if err != nil {
+			return lastIndexPoint, errors.Wrap(err, "failed to get new reporter info list after inserting new hex address list")
+
+		}
+
+		for _, reporter := range repoterInfoList {
+			idx.Vim[reporter.OperatorAddress] = int64(reporter.ID)
+		}
+
+		idx.Debugf("changed vim length: %d", len(idx.Vim))
+	}
+
+	modelList := make([]model.BabylonBTCRoll, 0)
+	for _, bie := range bieSummaryList {
+		for _, e := range bie.BTCInsertEvents {
+			reporterID, exist := idx.Vim[e.ReporterAddress]
+			if !exist {
+				return lastIndexPoint, errors.New("failed to find reporter ID in indexer ID maps")
+			}
+
+			modelList = append(modelList, model.BabylonBTCRoll{
+				ChainInfoID: idx.ChainInfoID,
+				Height:      bie.BlockHeight,
+				ReporterID:  reporterID,
+				HeaderCount: len(e.BTCHeaders),
+				BTCHeaders:  e.ToHeadersStringSlice(),
+			})
+
+		}
+	}
+
+	//  only loggic when there are miss validators in the network
+	if len(modelList) > 0 {
+		idx.Infof("found %d BTC insert events from %d to %d in the network", len(modelList), startHeight, endHeight)
+	}
+
+	// insert model list and update index pointer
+	err := idx.InsertBabylonBTCRollList(idx.ChainInfoID, endHeight, modelList)
+	if err != nil {
+		return lastIndexPoint, errors.Wrapf(err, "failed to insert from %d to %d height", startHeight, endHeight)
+	}
+
+	idx.updatePrometheusMetrics(endHeight)
+	return endHeight, nil
+}

--- a/internal/packages/babylon-btc-lightclient/model/model.go
+++ b/internal/packages/babylon-btc-lightclient/model/model.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+type BabylonBTCRoll struct {
+	bun.BaseModel `bun:"table:babylon_btc_lightclient"`
+	ID            int64  `bun:"id,pk,autoincrement"`
+	ChainInfoID   int64  `bun:"chain_info_id,pk,notnull"`
+	Height        int64  `bun:"height,notnull"`
+	ReporterID    int64  `bun:"reporter_id,notnull"`
+	HeaderCount   int    `bun:"header_count,notnull"`
+	BTCHeaders    string `bun:"btc_headers,notnull"`
+}
+
+func (bbr BabylonBTCRoll) String() string {
+	return fmt.Sprintf("BabylonBTCRoll<%d %d %d %d %s>",
+		bbr.ChainInfoID,
+		bbr.Height,
+		bbr.ReporterID,
+		bbr.HeaderCount,
+		bbr.BTCHeaders,
+	)
+}

--- a/internal/packages/babylon-btc-lightclient/repository/repository.go
+++ b/internal/packages/babylon-btc-lightclient/repository/repository.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/cosmostation/cvms/internal/common"
+	idxmodel "github.com/cosmostation/cvms/internal/common/indexer/model"
+	indexerrepo "github.com/cosmostation/cvms/internal/common/indexer/repository"
+	dbhelper "github.com/cosmostation/cvms/internal/helper/db"
+	"github.com/cosmostation/cvms/internal/packages/babylon-btc-lightclient/model"
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+type BTCLightClientIndexerRepository struct {
+	IndexName  string
+	sqlTimeout time.Duration
+	*bun.DB
+	indexerrepo.IMetaRepository
+}
+
+func NewRepository(indexerDB common.IndexerDB, indexName string, sqlTimeout time.Duration) BTCLightClientIndexerRepository {
+	// Instantiate the meta repository
+	metarepo := indexerrepo.NewMetaRepository(indexerDB)
+
+	// Return a repository that implements both IMetaRepository and vote-specific logic
+	return BTCLightClientIndexerRepository{indexName, sqlTimeout, indexerDB.DB, metarepo}
+}
+
+func (repo *BTCLightClientIndexerRepository) InsertBabylonBTCRollList(chainInfoID int64, indexPointerHeight int64, modelList []model.BabylonBTCRoll) error {
+	ctx, cancel := context.WithTimeout(context.Background(), repo.sqlTimeout)
+	defer cancel()
+
+	// if nothing to insert, just update index pointer
+	if len(modelList) == 0 {
+		_, err := repo.
+			NewUpdate().
+			Model(&idxmodel.IndexPointer{}).
+			Set("pointer = ?", indexPointerHeight).
+			Where("chain_info_id = ?", chainInfoID).
+			Where("index_name = ?", repo.IndexName).
+			Exec(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update new index pointer")
+		}
+
+		return nil
+	}
+
+	// if there are records need to insert, insert records and index pointer in a tx
+	err := repo.RunInTx(
+		ctx,
+		nil,
+		func(ctx context.Context, tx bun.Tx) error {
+			_, err := tx.NewInsert().
+				Model(&modelList).
+				ExcludeColumn("id").
+				Exec(ctx)
+			if err != nil {
+				return errors.Wrapf(err, "failed to insert model list")
+			}
+
+			_, err = tx.
+				NewUpdate().
+				Model(&idxmodel.IndexPointer{}).
+				Set("pointer = ?", indexPointerHeight).
+				Where("chain_info_id = ?", chainInfoID).
+				Where("index_name = ?", repo.IndexName).
+				Exec(ctx)
+			if err != nil {
+				return errors.Wrapf(err, "failed to update new index pointer")
+			}
+
+			return nil
+		})
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to update records and index point in a transaction: %v", modelList)
+	}
+
+	return nil
+}
+
+func (repo *BTCLightClientIndexerRepository) DeleteOldRecords(chainID, retentionPeriod string) (
+	/* deleted rows */ int64,
+	/* unexpected error */ error,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), repo.sqlTimeout)
+	defer cancel()
+
+	// Parsing retention period
+	duration, err := dbhelper.ParseRetentionPeriod(retentionPeriod)
+	if err != nil {
+		return 0, err
+	}
+
+	// Calculate cutoff time duration
+	cutoffTime := time.Now().Add(duration)
+
+	// Make partition table name
+	partitionTableName := dbhelper.MakePartitionTableName(repo.IndexName, chainID)
+
+	// Query Execution
+	res, err := repo.NewDelete().
+		Model((*model.BabylonBTCRoll)(nil)).
+		ModelTableExpr(partitionTableName).
+		Where("timestamp < ?", cutoffTime).
+		Exec(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	rowsAffected, _ := res.RowsAffected()
+	return rowsAffected, nil
+}


### PR DESCRIPTION
## PR(Pull Request) Overview

Support Babylon BTC lightclient module to check vigilante reporters working doing well.

#### Changes

- [x] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update

#### Related Issue

Please reference the Issue number this PR addresses: #24 

#### Description of Changes

Describe the key changes or parts of the code that have been modified.

#### Testing Method

Run this version in dev instance. and Check testcodes.

#### Additional Information

Babylon operates a Bitcoin light client that stores Bitcoin chain headers.
The light client is maintained up to date by the Vigilante (more specifically, the Vigilante Reporter), which tracks BTC state and submits the latest BTC headers to Babylon.
Ensuring that the BTC light client is up to date and can recover from Bitcoin re-orgs is very important for both the BTC Staking and the BTC Timestamping protocols.
The CVMS tool will index the Babylon node events BTCRollForward and BTCRollBack