### PR TITLE
chore: update babylon finality provider indexer sig timeout interval

### DIFF
--- a/internal/packages/duty/finality-provider-indexer/indexer/batch_sync.go
+++ b/internal/packages/duty/finality-provider-indexer/indexer/batch_sync.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const finalitySigTimeout = 3
+
 // NOTE: in this package, the missed height means fp didn't broadcast the finality sig tx in height+1 block
 // for example, I didn't broadcast the tx at 100 block, that will make missed block for 99 height.
 func (idx *FinalityProviderIndexer) batchSync(lastIndexPointerHeight int64) (
@@ -22,7 +24,7 @@ func (idx *FinalityProviderIndexer) batchSync(lastIndexPointerHeight int64) (
 	// set starntHeight and endHeight for batch sync
 	// NOTE: end height will use latest height -1 for waiting latest vote status
 	startHeight := (lastIndexPointerHeight + 1)
-	endHeight := (idx.Lh.LatestHeight - 1)
+	endHeight := (idx.Lh.LatestHeight - finalitySigTimeout)
 	if startHeight > endHeight {
 		idx.Infof("no need to sync from %d height to %d height, so it'll skip the logic", startHeight, endHeight)
 		return lastIndexPointerHeight, nil


### PR DESCRIPTION
## PR(Pull Request) Overview

Update latest height interval for considering finalitySigTimeout = 3 in current testnet. 

>  If I understand it correctly you use latestHeight - 1 for endHeight of each update. I would suggest using latestHeight - 3 is better as we have finality-sig-timeout=3. That is, e.g., if a vote for height 100 is submitted at babylon tip 103, it should be counted but if the tip height is 104, it should not be counted. This aligns with our jailing mechanism - Gai

https://testnet.babylon.hoodscan.io/parameters

#### Changes

- [ ] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update

#### Related Issue

#24 
