### PR TITLE
feat: add a metric to let cosmos consumer chains see their last valset update

### DIFF
--- a/docker/prometheus/rules/uptime.yaml
+++ b/docker/prometheus/rules/uptime.yaml
@@ -1,6 +1,13 @@
 groups:
   - name: UptimePackage
     rules:
+      # - alert: UptimeNoCCVUpdate
+      #   expr: |
+      #       cvms_block_height - on(chain_id) cvms_uptime_last_ccv_update > 5000
+      #   labels:
+      #     severity: critical
+      #   annotations:
+      #     summary: The chain has not received a validator set update in the last 5000 blocks.
       # - alert: IncreasingMissCounterOver30%During1h
       #   expr: |
       #     # 30mins ago, the validator is unjailed. but got jailed 

--- a/internal/packages/consensus/uptime/api/api.go
+++ b/internal/packages/consensus/uptime/api/api.go
@@ -85,16 +85,24 @@ func GetConsumserUptimeStatus(exporter *common.Exporter, chainID string) (types.
 		return types.CommonUptimeStatus{}, errors.Cause(err)
 	}
 	exporter.Debugf("got total consumer validator uptime: %d", len(validatorUptimeStatus))
-
 	// 5. get on-chain slashing parameter
 	signedBlocksWindow, minSignedPerWindow, err := getUptimeParams(consumerClient, exporter.ChainName)
 	if err != nil {
 		return types.CommonUptimeStatus{}, errors.Cause(err)
 	}
 
+	// 6. get consumer channel uptime status
+	consumerUptimeStatus := &types.ConsumerUptimeStatus{}
+	channelStatus, err := getLastCCVUpdate(consumerClient)
+	if err != nil {
+		return types.CommonUptimeStatus{}, errors.Wrap(err, "failed to get CCV channel status")
+	}
+	consumerUptimeStatus.LastCCVUpdate = channelStatus
+
 	return types.CommonUptimeStatus{
-		SignedBlocksWindow: signedBlocksWindow,
-		MinSignedPerWindow: minSignedPerWindow,
-		Validators:         validatorUptimeStatus,
+		SignedBlocksWindow:   signedBlocksWindow,
+		MinSignedPerWindow:   minSignedPerWindow,
+		Validators:           validatorUptimeStatus,
+		ConsumerUptimeStatus: consumerUptimeStatus,
 	}, nil
 }

--- a/internal/packages/consensus/uptime/api/uptime.go
+++ b/internal/packages/consensus/uptime/api/uptime.go
@@ -3,7 +3,10 @@ package api
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"sync"
@@ -299,4 +302,47 @@ func sliceStakingValidatorByVP(stakingValidators []commontypes.CosmosStakingVali
 		return tokensI > tokensJ // Sort in descending order
 	})
 	return stakingValidators[:totalConsensusValidators]
+}
+
+func getLastCCVUpdate(c common.CommonClient) (uint64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
+	defer cancel()
+
+	requester := c.APIClient.R().SetContext(ctx)
+	queryParams := url.Values{}
+	queryParams.Add("query", "ccv_packet.valset_update_id>1")
+	queryParams.Add("order_by", "ORDER_BY_DESC")
+	queryParams.Add("page", "1")
+	queryParams.Add("limit", "1")
+	endpoint := "/cosmos/tx/v1beta1/txs?" + queryParams.Encode()
+	c.Infof("endpoint: %s", endpoint)
+	resp, err := requester.Get(endpoint)
+	if err != nil {
+		return 0, errors.Cause(err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return 0, errors.Errorf("api error: got %d code from %s", resp.StatusCode(), resp.Request.URL)
+	}
+
+	var result struct {
+		TxResponses []struct {
+			Height string `json:"height"`
+		} `json:"tx_responses"`
+	}
+
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return 0, errors.Cause(err)
+	}
+
+	if len(result.TxResponses) == 0 {
+		c.Warnf("No CCV update found in consumer chain")
+		return 0, nil
+	}
+
+	height, err := strconv.ParseUint(result.TxResponses[0].Height, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse height from tx (%+v): %w", result, err)
+	}
+
+	return height, nil
 }

--- a/internal/packages/consensus/uptime/collector/collector.go
+++ b/internal/packages/consensus/uptime/collector/collector.go
@@ -28,6 +28,7 @@ const (
 	JailedMetricName             = "jailed"
 	SignedBlocksWindowMetricName = "signed_blocks_window"
 	MinSignedPerWindowMetricName = "min_signed_per_window"
+	LastCCVUpdateMetricName      = "last_ccv_update"
 )
 
 func Start(p common.Packager) error {
@@ -100,6 +101,12 @@ func loop(exporter *common.Exporter, p common.Packager) {
 		Namespace:   common.Namespace,
 		Subsystem:   Subsystem,
 		Name:        MinSignedPerWindowMetricName,
+		ConstLabels: packageLabels,
+	})
+	lastCCVUpdateMetric := p.Factory.NewGauge(prometheus.GaugeOpts{
+		Namespace:   common.Namespace,
+		Subsystem:   Subsystem,
+		Name:        LastCCVUpdateMetricName,
 		ConstLabels: packageLabels,
 	})
 
@@ -188,6 +195,11 @@ func loop(exporter *common.Exporter, p common.Packager) {
 		// update metrics by each chain
 		signedBlocksWindowMetric.Set(status.SignedBlocksWindow)
 		minSignedPerWindowMetric.Set(status.MinSignedPerWindow)
+
+		// Update consumer metrics
+		if status.ConsumerUptimeStatus != nil {
+			lastCCVUpdateMetric.Set(float64(status.ConsumerUptimeStatus.LastCCVUpdate))
+		}
 
 		exporter.Infof("updated metrics successfully and going to sleep %s ...", SubsystemSleep.String())
 

--- a/internal/packages/consensus/uptime/types/types_common.go
+++ b/internal/packages/consensus/uptime/types/types_common.go
@@ -7,9 +7,15 @@ var (
 
 // common
 type CommonUptimeStatus struct {
-	MinSignedPerWindow float64                 `json:"slash_winodw"`
-	SignedBlocksWindow float64                 `json:"vote_period"`
-	Validators         []ValidatorUptimeStatus `json:"validators"`
+	MinSignedPerWindow   float64                 `json:"slash_winodw"`
+	SignedBlocksWindow   float64                 `json:"vote_period"`
+	Validators           []ValidatorUptimeStatus `json:"validators"`
+	ConsumerUptimeStatus *ConsumerUptimeStatus   `json:"consumer_uptime_status"`
+}
+
+// consumer uptime status
+type ConsumerUptimeStatus struct {
+	LastCCVUpdate uint64 `json:"last_ccv_update"`
 }
 
 // cosmos uptime status


### PR DESCRIPTION
## PR(Pull Request) Overview

Added a metric to expose the last block height at which a consumer chain received a validator set update. This allows validators to ensure that relay channels are still up and that the ccv module is working as expected. I couldn't find an uptime_test.go so I didn't add a test, but let me know where it should go and I'll add it.

#### Changes

- [x] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update

#### Related Issue


#### Description of Changes

Added code to fetch the block height when a consumer chain last received a validator set update. Exposed a prometheus metric with the block time. Also added a commented-out example alert rule in uptime.yaml that'll alert when it's been > 5000 blocks since the last valset update. This can be indicative of relayer issues, and should be investigated in all cases.

#### Testing Method

1. Try the following config.yaml:
```
chains: 
  - display_name: 'gaia-1'
    chain_id: cosmoshub-4
    tracking_addresses: []
    nodes:
      - rpc: 'https://cosmos-rpc.stakeandrelax.net/'
        api: 'https://cosmos-api.stakeandrelax.net/'
        grpc: 'cosmos-grpc.stakeandrelax.net:15090'
  - display_name: 'neutron'
    chain_id: neutron-1
    tracking_addresses: []
    nodes:
      - rpc: 'https://rpc.neutron.quokkastake.io/'
        api: 'https://api.neutron.quokkastake.io/'
        grpc: 'rpc.neutron.quokkastake.io:9090'
    provider_nodes:
      - rpc: 'https://cosmos-rpc.stakeandrelax.net/'
        api: 'https://cosmos-api.stakeandrelax.net/'
        grpc: 'cosmos-grpc.stakeandrelax.net:15090'
```
2. cvms will now expose a metric called `cvms_uptime_last_ccv_update` that should give you the block height at last CCV update for Neutron mainnet.
3. You may then query it as `max by(chain_id) (cvms_block_height) - on(chain_id) cvms_uptime_last_ccv_update` and it looks like this:
![Screenshot 2025-02-11 at 4 32 04 PM](https://github.com/user-attachments/assets/2f575fbd-331a-4a80-ac17-a43c98ac72b0)

#### Additional Information
