### PR TITLE
Update support_chains.yaml

### DIFF
--- a/docker/cvms/support_chains.yaml
+++ b/docker/cvms/support_chains.yaml
@@ -707,6 +707,17 @@ lum-network-1:
     - upgrade
     - uptime
     - voteindexer
+lumera-testnet-1:
+  chain_name: lumera
+  protocol_type: cosmos
+  mainnet: false
+  support_asset:
+    denom: ulume
+    decimal: 6
+  packages:
+    - block
+    - upgrade
+    - uptime
 mantle-1:
   chain_name: asset-mantle
   protocol_type: cosmos

--- a/docker/cvms/support_chains.yaml
+++ b/docker/cvms/support_chains.yaml
@@ -1246,7 +1246,7 @@ uni-6:
     - upgrade
     - uptime
     - voteindexer
-union-testnet-8:
+union-testnet-9:
   chain_name: union
   protocol_type: cosmos
   mainnet: false

--- a/docker/cvms/support_chains.yaml
+++ b/docker/cvms/support_chains.yaml
@@ -1246,7 +1246,7 @@ uni-6:
     - upgrade
     - uptime
     - voteindexer
-union-testnet-9:
+union-testnet-8:
   chain_name: union
   protocol_type: cosmos
   mainnet: false


### PR DESCRIPTION
add `lumera-testnet-1` information

## PR(Pull Request) Overview

Briefly describe the changes made in this PR.

#### Changes

- [ ] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update
☑ New chain params addition

#### Related Issue

N/A

#### Description of Changes

Added `lumera-testnet-1` chain parameters 

#### Testing Method

Tested locally by setting the node's endpoints

```
.resource/config.yaml:

chains:
  - display_name: 'lumera'
    chain_id: lumera-testnet-1
    tracking_addresses:
      - 'lumera1xxxxx'
    nodes:
      - rpc: 'http://${NODE_IP}:26657'
        api: 'http://${NODE_IP}:1317'
        grpc: '${NODE_IP}:9090'
```

Results:

```
cvms-alertmanager  | ts=2025-02-20T17:43:55.288Z caller=cluster.go:700 level=info component=cluster msg="gossip settled; proceeding" elapsed=10.009704004s
cvms-exporter      | level="error" msg="api error: Get \"http://xx.xx.xx:1317/cosmos/upgrade/v1beta1/current_plan\": context deadline exceeded" chain="lumera" chain_id="lumera-testnet-1" package="upgrade"
cvms-exporter      | level="error" msg="failed to update metrics: cvms common errors: failed to request from node" chain="lumera" chain_id="lumera-testnet-1" package="upgrade"
cvms-exporter      | level="error" msg="api error: Get \"http://xx.xx.xx.xx:1317/cosmos/bank/v1beta1/balances/lumera1xxxxxxxxx\": context deadline exceeded" chain="lumera" chain_id="lumera-testnet-1" package="balance"
cvms-exporter      | level="error" msg="failed to collect all accounts balances, got errors count: 1" chain="lumera" chain_id="lumera-testnet-1" package="balance"
cvms-exporter      | level="error" msg="failed to update metrics: cvms common errors: failed to request from node"
cvms-exporter      | level="error" msg="failed to update metrics err: Get \"http://xx.xx.xx.xx:1317/cosmos/staking/v1beta1/validators?status=BOND_STATUS_BONDED&pagination.count_total=true&pagination.limit=500\": context deadline exceeded and going to sleep 10s..." chain="lumera" chain_id="lumera-testnet-1" package="uptime"
cvms-exporter      | level="info" msg="updated metrics successfully and going to sleep 15s ..." chain="lumera" chain_id="lumera-testnet-1" package="block"
cvms-exporter      | level="warning" msg="RPC endpoint will be changed with health endpoint for this package: http://xx.xx.xx.xxx:26657/" chain="lumera" chain_id="lumera-testnet-1" package="uptime"
cvms-exporter      | level="error" msg="failed to get any health endpoints from healthcheck filter, retry sleep 10s" chain="lumera" chain_id="lumera-testnet-1" package="uptime"
cvms-exporter      | level="info" msg="updated metrics successfully and going to sleep 15s ..." chain="lumera" chain_id="lumera-testnet-1" package="block"
cvms-exporter      | level="warning" msg="RPC endpoint will be changed with health endpoint for this package: http://xx.xx.xx.xx:26657/" chain="lumera" chain_id="lumera-testnet-1" package="uptime"
cvms-exporter      | level="error" msg="failed to get any health endpoints from healthcheck filter, retry sleep 10s" chain="lumera" chain_id="lumera-testnet-1" package="uptime"
cvms-exporter      | level="warning" msg="RPC endpoint will be changed with health endpoint for this package: http://xx.xx.xx.xxx:26657/" chain="lumera" chain_id="lumera-testnet-1" package="uptime"
cvms-exporter      | level="error" msg="failed to get any health endpoints from healthcheck filter, retry sleep 10s" chain="lumera" chain_id="lumera-testnet-1" package="uptime"
cvms-exporter      | level="info" msg="updated metrics successfully and going to sleep 15s ..." chain="lumera" chain_id="lumera-testnet-1" package="block"
cvms-exporter      | level="warning" msg="RPC endpoint will be changed with health endpoint for this package: http://xx.xx.xx.xxx:26657/" chain="lumera" chain_id="lumera-testnet-1" package="uptime"
cvms-exporter      | level="error" msg="failed to get any health endpoints from healthcheck filter, retry sleep 10s" chain="lumera" chain_id="lumera-testnet-1" package="uptime"
```

#### Additional Information

N/A