### PR TITLE
Feature/add log monitoring

### DIFF
--- a/.resource/.env.example
+++ b/.resource/.env.example
@@ -7,6 +7,8 @@
 # CUSTOM_CHAINS_FILE=custom_chains.yaml
 # If you don't want to delete old records, use "persistence" instead of specific period
 # DB_RETENTION_PERIOD=1h 
+# If you're operating docker service in not default directory, please enable this env for cadvisor and promtail
+# DOCKER_ROOT=/data/docker
 
 ####### Prometheus Service #######
 # PROM_SERVER_PORT=9090

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,14 @@
+x-logging: &logging
+  logging:
+    driver: json-file
+    options:
+      max-size: 100m
+      max-file: '3'
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+
 services:
   exporter:
+    <<: *logging
     build: .
     image: cosmostation/cvms:latest
     container_name: cvms-exporter
@@ -25,6 +34,7 @@ services:
       - cvms-net
 
   prometheus:
+    <<: *logging
     image: prom/prometheus:latest
     container_name: cvms-exporter-db
     extra_hosts:
@@ -45,6 +55,7 @@ services:
     restart: unless-stopped
 
   indexer:
+    <<: *logging
     build: .
     image: cosmostation/cvms:latest
     container_name: cvms-indexer
@@ -79,6 +90,7 @@ services:
       - postgres
 
   postgres:
+    <<: *logging
     image: postgres:16.4
     container_name: cvms-indexer-db
     restart: unless-stopped
@@ -116,6 +128,7 @@ services:
       - cvms-net
 
   grafana:
+    <<: *logging
     image: grafana/grafana:latest
     container_name: cvms-grafana
     restart: unless-stopped
@@ -148,6 +161,7 @@ services:
       - cvms-net
 
   alertmanager:
+    <<: *logging
     image: prom/alertmanager:latest
     container_name: cvms-alertmanager
     restart: unless-stopped
@@ -163,6 +177,46 @@ services:
     ports:
       - ${ALERTMANAGER_SERVER_PORT:-9093}:9093
 
+  promtail:
+    image: grafana/promtail:latest
+    user: root
+    volumes:
+      - /etc/machine-id:/etc/machine-id:ro
+      - ./docker/promtail:/etc/promtail
+      - promtail-volume:/tmp
+      - ${DOCKER_ROOT:-/var/lib/docker}/containers:/var/lib/docker/containers:ro,rslave
+    command:
+      - '/usr/bin/promtail'
+      - '--config.file=/promtail-config.yml'
+    environment:
+      SERVER_LABEL_HOSTNAME: cvms
+    restart: 'unless-stopped'
+    depends_on:
+      - loki
+    <<: *logging
+    labels:
+      - metrics.scrape=true
+      - metrics.path=/metrics
+      - metrics.port=9080
+      - metrics.instance=promtail
+      # - metrics.network=${NETWORK}
+
+  loki:
+    image: grafana/loki:latest
+    volumes:
+      - loki-volume:/tmp
+      - ./docker/loki:/etc/loki
+    command:
+      - '--config.file=/etc/loki/loki.yml'
+    restart: 'unless-stopped'
+    <<: *logging
+    labels:
+      - metrics.scrape=true
+      - metrics.path=/metrics
+      - metrics.port=3100
+      - metrics.instance=loki
+      # - metrics.network=${NETWORK}
+
 networks:
   cvms-net:
     name: cvms-net
@@ -177,3 +231,5 @@ volumes:
     name: exporter-db-volume
   indexer-db-volume:
     name: indexer-db-volume
+  promtail-volume:
+  loki-volume:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -188,8 +188,6 @@ services:
       - ${DOCKER_ROOT:-/var/lib/docker}/containers:/var/lib/docker/containers:ro,rslave
     command:
       - '--config.file=/etc/promtail/promtail-config.yaml'
-    environment:
-      SERVER_LABEL_HOSTNAME: cvms
     restart: 'unless-stopped'
     networks: ['cvms-net']
     depends_on: ['loki']

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -178,6 +178,7 @@ services:
       - ${ALERTMANAGER_SERVER_PORT:-9093}:9093
 
   promtail:
+    container_name: cvms-promtail
     image: grafana/promtail:latest
     user: root
     volumes:
@@ -186,13 +187,12 @@ services:
       - promtail-volume:/tmp
       - ${DOCKER_ROOT:-/var/lib/docker}/containers:/var/lib/docker/containers:ro,rslave
     command:
-      - '/usr/bin/promtail'
-      - '--config.file=/promtail-config.yml'
+      - '--config.file=/etc/promtail/promtail-config.yaml'
     environment:
       SERVER_LABEL_HOSTNAME: cvms
     restart: 'unless-stopped'
-    depends_on:
-      - loki
+    networks: ['cvms-net']
+    depends_on: ['loki']
     <<: *logging
     labels:
       - metrics.scrape=true
@@ -202,19 +202,42 @@ services:
       # - metrics.network=${NETWORK}
 
   loki:
+    container_name: cvms-loki
     image: grafana/loki:latest
     volumes:
       - loki-volume:/tmp
       - ./docker/loki:/etc/loki
     command:
-      - '--config.file=/etc/loki/loki.yml'
+      - '--config.file=/etc/loki/loki.yaml'
     restart: 'unless-stopped'
+    networks: ['cvms-net']
     <<: *logging
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics
       - metrics.port=3100
       - metrics.instance=loki
+      # - metrics.network=${NETWORK}
+  cadvisor:
+    container_name: cvms-cadvisor
+    restart: 'unless-stopped'
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /:/rootfs:ro,rslave
+      - /var/run:/var/run
+      - /sys:/sys:ro,rslave
+      - ${DOCKER_ROOT:-/var/lib/docker}:/var/lib/docker:ro,rslave
+    command:
+      - --docker_only
+      - --housekeeping_interval=30s
+    networks: ['cvms-net']
+    <<: *logging
+    labels:
+      - metrics.scrape=true
+      - metrics.path=/metrics
+      - metrics.port=8080
+      - metrics.instance=cadvisor
       # - metrics.network=${NETWORK}
 
 networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -194,12 +194,6 @@ services:
     networks: ['cvms-net']
     depends_on: ['loki']
     <<: *logging
-    labels:
-      - metrics.scrape=true
-      - metrics.path=/metrics
-      - metrics.port=9080
-      - metrics.instance=promtail
-      # - metrics.network=${NETWORK}
 
   loki:
     container_name: cvms-loki
@@ -212,12 +206,7 @@ services:
     restart: 'unless-stopped'
     networks: ['cvms-net']
     <<: *logging
-    labels:
-      - metrics.scrape=true
-      - metrics.path=/metrics
-      - metrics.port=3100
-      - metrics.instance=loki
-      # - metrics.network=${NETWORK}
+
   cadvisor:
     container_name: cvms-cadvisor
     restart: 'unless-stopped'
@@ -233,12 +222,6 @@ services:
       - --housekeeping_interval=30s
     networks: ['cvms-net']
     <<: *logging
-    labels:
-      - metrics.scrape=true
-      - metrics.path=/metrics
-      - metrics.port=8080
-      - metrics.instance=cadvisor
-      # - metrics.network=${NETWORK}
 
 networks:
   cvms-net:

--- a/docker/grafana/provisioning/dashboards/cvms-cadvisor-dashboard.json
+++ b/docker/grafana/provisioning/dashboards/cvms-cadvisor-dashboard.json
@@ -105,10 +105,7 @@
       "options": {
         "alertThreshold": true,
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
+          "calcs": ["mean", "max"],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -219,10 +216,7 @@
       "options": {
         "alertThreshold": true,
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
+          "calcs": ["mean", "max"],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -320,10 +314,7 @@
       "options": {
         "alertThreshold": true,
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
+          "calcs": ["mean", "max"],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -434,10 +425,7 @@
       "options": {
         "alertThreshold": true,
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
+          "calcs": ["mean", "max"],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -535,10 +523,7 @@
       "options": {
         "alertThreshold": true,
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
+          "calcs": ["mean", "max"],
           "displayMode": "table",
           "placement": "right",
           "showLegend": true
@@ -662,9 +647,7 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true,
@@ -726,10 +709,7 @@
   "preload": false,
   "refresh": "30s",
   "schemaVersion": 40,
-  "tags": [
-    "cadvisor",
-    "docker"
-  ],
+  "tags": ["cadvisor", "docker"],
   "templating": {
     "list": [
       {
@@ -782,7 +762,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "CVMS cadvisor",
-  "uid": "pMEd7m0Mz",
+  "uid": "cvms_cadvisor",
   "version": 3,
   "weekStart": ""
 }

--- a/docker/grafana/provisioning/dashboards/cvms-cadvisor-dashboard.json
+++ b/docker/grafana/provisioning/dashboards/cvms-cadvisor-dashboard.json
@@ -1,0 +1,788 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 11,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "panels": [],
+      "title": "CPU",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cvms_exporter_db"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 15,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cvms_exporter_db"
+          },
+          "expr": "sum(rate(container_cpu_usage_seconds_total{instance=~\"$host\",name=~\"$container\",name=~\".+\"}[5m])) by (name) *100",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Memory",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cvms_exporter_db"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 9,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cvms_exporter_db"
+          },
+          "expr": "sum(container_memory_rss{instance=~\"$host\",name=~\"$container\",name=~\".+\"}) by (name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cvms_exporter_db"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 14,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cvms_exporter_db"
+          },
+          "expr": "sum(container_memory_cache{instance=~\"$host\",name=~\"$container\",name=~\".+\"}) by (name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Cached",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 2,
+      "panels": [],
+      "title": "Network",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cvms_exporter_db"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 4,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cvms_exporter_db"
+          },
+          "expr": "sum(rate(container_network_receive_bytes_total{instance=~\"$host\",name=~\"$container\",name=~\".+\"}[5m])) by (name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Received Network Traffic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cvms_exporter_db"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cvms_exporter_db"
+          },
+          "expr": "sum(rate(container_network_transmit_bytes_total{instance=~\"$host\",name=~\"$container\",name=~\".+\"}[5m])) by (name)",
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sent Network Traffic",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 19,
+      "panels": [],
+      "title": "Misc",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cvms_exporter_db"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "id"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 260
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Running"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "d"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 17,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cvms_exporter_db"
+          },
+          "expr": "(time() - container_start_time_seconds{instance=~\"$host\",name=~\"$container\",name=~\".+\"})/86400",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Containers Info",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "container_label_com_docker_compose_project",
+                "container_label_com_docker_compose_project_working_dir",
+                "image",
+                "instance",
+                "name",
+                "Value",
+                "container_label_com_docker_compose_service"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Running",
+              "container_label_com_docker_compose_project": "Label",
+              "container_label_com_docker_compose_project_working_dir": "Working dir",
+              "container_label_com_docker_compose_service": "Service",
+              "image": "Registry Image",
+              "instance": "Instance",
+              "name": "Name"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [
+    "cadvisor",
+    "docker"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "cvms_exporter_db",
+        "definition": "label_values({__name__=~\"container.*\"},instance)",
+        "includeAll": true,
+        "label": "Host",
+        "name": "host",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"container.*\"},instance)",
+          "refId": "Prometheus-host-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "cvms_exporter_db",
+        "definition": "label_values({__name__=~\"container.*\", instance=~\"$host\"},name)",
+        "includeAll": true,
+        "label": "Container",
+        "name": "container",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"container.*\", instance=~\"$host\"},name)",
+          "refId": "Prometheus-container-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CVMS cadvisor",
+  "uid": "pMEd7m0Mz",
+  "version": 3,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/dashboards/cvms-management-dashboard.json
+++ b/docker/grafana/provisioning/dashboards/cvms-management-dashboard.json
@@ -1,0 +1,164 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 9,
+  "links": [],
+  "panels": [
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "alertInstanceLabelFilter": "",
+        "alertName": "",
+        "dashboardAlerts": false,
+        "groupBy": [],
+        "groupMode": "default",
+        "maxItems": 20,
+        "showInactiveAlerts": false,
+        "sortOrder": 1,
+        "stateFilter": {
+          "error": true,
+          "firing": true,
+          "noData": false,
+          "normal": false,
+          "pending": true
+        },
+        "viewMode": "list"
+      },
+      "pluginVersion": "11.5.1",
+      "title": "CVMS Alert List",
+      "type": "alertlist"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "cvms_loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Ascending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "cvms_loki"
+          },
+          "direction": "forward",
+          "editorMode": "builder",
+          "expr": "{container_name=\"cvms-indexer\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "CVMS Indexer Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "cvms_loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Ascending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "cvms_loki"
+          },
+          "direction": "forward",
+          "editorMode": "builder",
+          "expr": "{container_name=\"cvms-exporter\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "CVMS Exporter Logs",
+      "type": "logs"
+    }
+  ],
+  "preload": false,
+  "refresh": "auto",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "CVMS Management",
+  "uid": "cvms_management",
+  "version": 2,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/dashboards/dashboard.yaml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yaml
@@ -27,3 +27,11 @@ providers:
     editable: true
     options:
       path: /etc/grafana/provisioning/dashboards/cvms-management-dashboard.json
+
+  - name: 'CVMS cadvisor'
+    orgId: 1
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/cvms-cadvisor-dashboard.json.json

--- a/docker/grafana/provisioning/dashboards/dashboard.yaml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yaml
@@ -34,4 +34,4 @@ providers:
     disableDeletion: false
     editable: true
     options:
-      path: /etc/grafana/provisioning/dashboards/cvms-cadvisor-dashboard.json.json
+      path: /etc/grafana/provisioning/dashboards/cvms-cadvisor-dashboard.json

--- a/docker/grafana/provisioning/dashboards/dashboard.yaml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yaml
@@ -19,3 +19,11 @@ providers:
     editable: true
     options:
       path: /etc/grafana/provisioning/dashboards/network
+
+  - name: 'CVMS Logs'
+    orgId: 1
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/cvms-management-dashboard.json

--- a/docker/grafana/provisioning/datasources/datasources.yaml
+++ b/docker/grafana/provisioning/datasources/datasources.yaml
@@ -26,3 +26,11 @@ datasources:
       sslmode: 'disable' # disable/require/verify-ca/verify-full
       postgresVersion: 1604 # 903=9.3, 904=9.4, 905=9.5, 906=9.6, 1000=10
       timescaledb: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    uid: cvms_loki
+    url: http://loki:3100
+    editable: true

--- a/docker/loki/loki.yaml
+++ b/docker/loki/loki.yaml
@@ -1,0 +1,40 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+compactor:
+  working_directory: /tmp/loki/retention
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem
+
+schema_config:
+  configs:
+    - from: 2024-05-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: tsdb_index
+        period: 24h
+
+limits_config:
+  retention_period: 30d
+  ingestion_rate_mb: 128
+  ingestion_burst_size_mb: 512

--- a/docker/prometheus/prometheus.yaml
+++ b/docker/prometheus/prometheus.yaml
@@ -43,3 +43,13 @@ scrape_configs:
     metrics_path: '/metrics'
     static_configs:
       - targets: ['cvms-cadvisor:8080']      
+
+  - job_name: 'loki'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['loki:3100']      
+
+  - job_name: 'promtail'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['promtail:9080']      

--- a/docker/prometheus/prometheus.yaml
+++ b/docker/prometheus/prometheus.yaml
@@ -38,3 +38,8 @@ scrape_configs:
     metrics_path: '/metrics'
     static_configs:
       - targets: ['cvms-exporter-db:9090']      
+
+  - job_name: 'cadvisor'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['cvms-cadvisor:8080']      

--- a/docker/promtail/promtail-config.yaml
+++ b/docker/promtail/promtail-config.yaml
@@ -1,0 +1,50 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 9081
+  log_level: warn
+
+positions:
+  filename: /tmp/positions.yaml
+
+scrape_configs:
+- job_name: containers
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: containerlogs
+      server: cvms
+      __path__: /var/lib/docker/containers/*/*log
+
+  pipeline_stages:
+  - json:
+      expressions:
+        output: log
+        stream: stream
+        attrs:
+
+  - json:
+      expressions:
+        tag:
+      source: attrs
+
+  - regex:
+      expression: (?P<image_name>(?:[^|]*[^|])).(?P<container_name>(?:[^|]*[^|])).(?P<image_id>(?:[^|]*[^|])).(?P<container_id>(?:[^|]*[^|]))
+      source: tag
+
+  - timestamp:
+      format: RFC3339Nano
+      source: time
+
+  - labels:
+      stream:
+      container_name:
+
+  - labeldrop:
+    - filename
+
+  - output:
+      source: output
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push

--- a/docker/promtail/promtail-config.yaml
+++ b/docker/promtail/promtail-config.yaml
@@ -5,7 +5,7 @@ server:
 
 positions:
   filename: /tmp/positions.yaml
-
+  
 scrape_configs:
 - job_name: containers
   static_configs:


### PR DESCRIPTION
## PR(Pull Request) Overview

Briefly describe the changes made in this PR.

This PR integrates cAdvisor, Loki, and Promtail into the CVMS repository to provide built-in infrastructure monitoring and container-level logging support.

#### Changes

- [x] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update

#### Description of Changes

•	Added cadvisor as a container monitoring agent to expose Prometheus metrics (CPU, memory, network, etc.) for all running CVMS containers.
•	Added loki as a lightweight log aggregation system compatible with Promtail and Grafana.
•	Added promtail as a log collector to tail Docker container logs and push them to Loki.
•	Updated Docker Compose configuration to include these services under the shared monitoring network.
•	Ensured log tags are structured to work with CVMS container names and images for easy filtering and visualization.

#### Additional Information

The integration of these services was inspired by [eth-docker](https://github.com/eth-educational/eth-docker), which provides a production-ready setup for observability using cAdvisor, Loki, and Promtail. Similar patterns and configurations have been adapted to fit the CVMS architecture.
