### PR TITLE
fix: add support postgres existingSecret for indexer

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -118,10 +118,24 @@ Get PostgreSQL user
 {{- end -}}
 
 {{/*
-Get PostgreSQL password
+Get PostgreSQL password value
 */}}
-{{- define "cvms.postgresql.password" -}}
-{{- ternary .Values.postgresql.auth.password .Values.postgresql.external.password .Values.postgresql.enabled | quote -}}
+{{- define "cvms.postgresql.password.value" -}}
+{{- if .Values.postgresql.enabled -}}
+  {{- if not .Values.postgresql.auth.existingSecret -}}
+    {{- if .Values.postgresql.auth.password -}}
+      {{ .Values.postgresql.auth.password | quote }}
+    {{- else -}}
+      {{- fail "PostgreSQL password must be set either through postgresql.auth.password or postgresql.auth.existingSecret when postgresql.enabled is true" -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- if .Values.postgresql.external.password -}}
+    {{ .Values.postgresql.external.password | quote }}
+  {{- else -}}
+    {{- fail "PostgreSQL external password must be set when postgresql.enabled is false" -}}
+  {{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/templates/indexer/deployment.yaml
+++ b/helm/templates/indexer/deployment.yaml
@@ -27,20 +27,30 @@ spec:
     spec:
       {{- if .Values.indexer.initContainers.enabled }}
       initContainers:
-      {{- range .Values.indexer.initContainers.containers }}
+        {{- range .Values.indexer.initContainers.containers }}
         - name: {{ .name }}
           image: {{ .image }}
           imagePullPolicy: {{ .imagePullPolicy }}
           command: 
-          {{- toYaml .command | nindent 10 }}
+            {{- toYaml .command | nindent 12 }}
           args:
-          {{- toYaml .args | nindent 10 }}
+            {{- toYaml .args | nindent 12 }}
+          env:
+            - name: DB_PASSWORD
+              {{- if and $.Values.postgresql.enabled $.Values.postgresql.auth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.postgresql.auth.existingSecret }}
+                  key: password
+              {{- else }}
+              value: {{ include "cvms.postgresql.password.value" $ }}
+              {{- end }}
           volumeMounts:
-          {{- range .volumeMounts }}
+            {{- range .volumeMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath | quote }}
-          {{- end }}
-      {{- end }}
+            {{- end }}
+        {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -76,7 +86,14 @@ spec:
             - name: DB_NAME
               value: {{ include "cvms.postgresql.database" . }}
             - name: DB_PASSWORD
-              value: {{ include "cvms.postgresql.password" . }}
+              {{- if and .Values.postgresql.enabled .Values.postgresql.auth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  key: password
+              {{- else }}
+              value: {{ include "cvms.postgresql.password.value" . }}
+              {{- end }}
             - name: DB_PORT
               value: {{ include "cvms.postgresql.port" . }}
             - name: DB_USER

--- a/helm/templates/sql-schema-configmap.yaml
+++ b/helm/templates/sql-schema-configmap.yaml
@@ -15,7 +15,6 @@ data:
     DB_PORT={{ include "cvms.postgresql.port" . }}
     DB_USER={{ include "cvms.postgresql.user" . }}
     DB_NAME={{ include "cvms.postgresql.database" . }}
-    DB_PASSWORD={{ include "cvms.postgresql.password" . }}
 
     # GitHub API URL for the schema directory
     SCHEMA_API_URL="https://api.github.com/repos/cosmostation/cvms/contents/docker/postgres/schema"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -470,9 +470,9 @@ postgresql:
   ## All of these values are only used when postgresql.enabled is set to false
   ## @param postgresql.external.host Database host
   ## @param postgresql.external.port Database port number
-  ## @param postgresql.external.user Non-root username for Kong
-  ## @param postgresql.external.password Password for the non-root username for Kong
-  ## @param postgresql.external.database Kong database name
+  ## @param postgresql.external.user Non-root username
+  ## @param postgresql.external.password Password for the non-root username
+  ## @param postgresql.external.database database name
   ## @param postgresql.external.existingSecret Name of an existing secret resource containing the database credentials
   ## @param postgresql.external.existingSecretPasswordKey Name of an existing secret key containing the database credentials
   ##


### PR DESCRIPTION
## PR(Pull Request) Overview

This PR adds support for indexer authentication to postgres database when using existingSecret instead of plain text password.

#### Changes

- [x] Major feature addition or modification
- [ ] Bug fix
- [ ] Code improvement
- [ ] Documentation update

#### Description of Changes

When we use postgres sub chart as dabase for indexer and use plain text password every time we update the helm chart config the postgresql sub-chart create a new secret and postgresql will be restarted, to prevent postgresql from restarting we should use existingSecret in the auth section of postgres config, this PR supports using the existing secret for indexer service.

#### Testing Method

Explain how to test the changes step by step:

1. Navigate to the helm directory.
2. Change the values.yaml file based on your desired configuration, the main config of cvms should be modified by cvmsConfig.monikers and cvmsConfig.chains.
3. Enable the serviceMonitor of indexer and exporter service.
4. Run helm install my-release cvms/helm to install the Helm chart.
5. Verify that the CVMS pods are running and healthy using kubectl get pods.
6. If you want to add metrics endpoints manually, check the services using kubectl get svc.
