### PR TITLE
Fix typos in function names and struct fields in common package

### DIFF
--- a/internal/common/packager.go
+++ b/internal/common/packager.go
@@ -115,7 +115,7 @@ func (p *Packager) SetInfoForBalancePackage(balanceAddresses []string, balanceDe
 	return p
 }
 
-func (p *Packager) SetAddtionalEndpoints(providerEndpoints Endpoints) *Packager {
+func (p *Packager) SetAdditionalEndpoints(providerEndpoints Endpoints) *Packager {
 	p.ProviderEndPoints = providerEndpoints
 	return p
 }

--- a/internal/common/types/cosmos.go
+++ b/internal/common/types/cosmos.go
@@ -62,7 +62,7 @@ type CosmosStatus struct {
 		LatestBlockTime     time.Time `json:"latest_block_time"`
 		EarliestBlockHash   string    `json:"earliest_block_hash"`
 		EarliestAppHash     string    `json:"earliest_app_hash"`
-		EarliestBlcokHeight string    `json:"earliest_block_height"`
+		EarliestBlockHeight string    `json:"earliest_block_height"`
 		EarliestBlockTime   time.Time `json:"earliest_block_time"`
 		CatchingUp          bool      `json:"catching_up"`
 	} `json:"sync_info" validate:"required"`
@@ -199,7 +199,7 @@ type CosmosProviderValidatorsResponse struct {
 	Validators []ProviderValidator `json:"validators"`
 }
 type ProviderValidator struct {
-	PrvodierValconsAddress string `json:"provider_address"`
+	ProviderValconsAddress string `json:"provider_address"`
 	ConsumerKey            struct {
 		Pubkey string `json:"ed25519"`
 	} `json:"consumer_key"`


### PR DESCRIPTION
Corrected multiple typos to improve code clarity and consistency:

- Renamed method SetAddtionalEndpoints to SetAdditionalEndpoints in packager.go
- Fixed Blcok → Block in CosmosStatus struct field name
- Fixed PrvodierValconsAddress → ProviderValconsAddress in ProviderValidator struct

These changes ensure accurate naming for improved maintainability and readability.