### PR TITLE
saga-testnet chain-id update

### DIFF
--- a/docker/cvms/support_chains.yaml
+++ b/docker/cvms/support_chains.yaml
@@ -826,7 +826,7 @@ lum-network-1:
     - upgrade
     - uptime
     - voteindexer
-lumera-testnet-1:
+lumera-testnet-2:
   chain_name: lumera
   protocol_type: cosmos
   mainnet: false

--- a/docker/cvms/support_chains.yaml
+++ b/docker/cvms/support_chains.yaml
@@ -1291,7 +1291,7 @@ ssc-1:
     - upgrade
     - uptime
     - voteindexer
-ssc-testnet-2:
+ssc-testnet-3:
   chain_name: saga
   protocol_type: cosmos
   mainnet: false


### PR DESCRIPTION
## PR(Pull Request) Overview

- Rename chain-id from `ssc-testnet-2` to `ssc-testnet-3`
- Rename chain-id from `lumera-testnet-1` to `lumera-testnet-2`

#### Changes

- [✅] Small modification

#### Additional Information

- Official Saga Discord Announcement about the reboot of the testnet: [reference](https://discord.com/channels/950275843949736006/1230976922012352633/1384237229370638396)

- Official Lumera Discord Announcement about the reboot of the testnet: [reference](https://discord.com/channels/774465063540097050/1341906774231351388/1390073729681457325)