### PR TITLE
Compatible with babylon v3 finality-provider module

### DIFF
--- a/internal/common/api/babylon.go
+++ b/internal/common/api/babylon.go
@@ -59,7 +59,7 @@ func GetFinalityVotesByHeight(c common.CommonClient, height int64) ([]string, er
 	return votes.BTCPKs, nil
 }
 
-func GetBabylonFinalityProviderInfos(c common.CommonClient) ([]types.FinalityProviderInfo, error) {
+func GetBabylonFinalityProviderInfos(c common.CommonClient, chainID string) ([]types.FinalityProviderInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
 	defer cancel()
 
@@ -68,7 +68,7 @@ func GetBabylonFinalityProviderInfos(c common.CommonClient) ([]types.FinalityPro
 	maxCnt := 10
 	key := ""
 	for cnt := 0; cnt <= maxCnt; cnt++ {
-		resp, err := requester.Get(types.BabylonFinalityProviderInfosQueryPath(key))
+		resp, err := requester.Get(types.BabylonFinalityProviderInfosQueryPath(key, chainID))
 		if err != nil {
 			return nil, errors.Errorf("rpc call is failed from %s: %s", resp.Request.URL, err)
 		}
@@ -86,7 +86,7 @@ func GetBabylonFinalityProviderInfos(c common.CommonClient) ([]types.FinalityPro
 
 		if fpInfos.Pagination.NextKey != "" {
 			key = url.QueryEscape(fpInfos.Pagination.NextKey)
-			c.Debugf("there is next key, keep collecting finality providers by using this path: %s", types.BabylonFinalityProviderInfosQueryPath(key))
+			c.Debugf("there is next key, keep collecting finality providers by using this path: %s", types.BabylonFinalityProviderInfosQueryPath(key, chainID))
 		} else {
 			// got all finality provider infos
 			c.Debugf("collected all finality providers")

--- a/internal/common/api/babylon_api_test.go
+++ b/internal/common/api/babylon_api_test.go
@@ -28,8 +28,8 @@ func TestCheckGetBlockResultAndExtractFpVoting(t *testing.T) {
 func Test_Babylon_GetFP(t *testing.T) {
 	commonApp := common.NewCommonApp(p)
 	commonApp.SetAPIEndPoint("https://lcd-office.cosmostation.io/babylon-testnet")
-
-	fps, err := GetBabylonFinalityProviderInfos(commonApp.CommonClient)
+	chainID := "bbn-testnet-5"
+	fps, err := GetBabylonFinalityProviderInfos(commonApp.CommonClient, chainID)
 	assert.NoError(t, err)
 
 	for _, fp := range fps {

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -229,8 +229,8 @@ func GetStakingValidators(client common.CommonClient, chainName string, newStaki
 	return nil
 }
 
-func MakeFinalityProviderInfoList(c common.CommonClient, chainInfoID int64, newFinalityProviderMap map[string]bool) ([]indexermodel.FinalityProviderInfo, error) {
-	fps, err := api.GetBabylonFinalityProviderInfos(c)
+func MakeFinalityProviderInfoList(c common.CommonClient, chainID string, chainInfoID int64, newFinalityProviderMap map[string]bool) ([]indexermodel.FinalityProviderInfo, error) {
+	fps, err := api.GetBabylonFinalityProviderInfos(c, chainID)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}

--- a/internal/common/types/babylon.go
+++ b/internal/common/types/babylon.go
@@ -40,8 +40,8 @@ type FinalityVotesResponse struct {
 	BTCPKs []string `json:"btc_pks"`
 }
 
-var BabylonFinalityProviderInfosQueryPath = func(key string) string {
-	return fmt.Sprintf("/babylon/btcstaking/v1/finality_providers?pagination.key=%s", key)
+var BabylonFinalityProviderInfosQueryPath = func(key, chainID string) string {
+	return fmt.Sprintf("/babylon/btcstaking/v1/finality_providers/%s?pagination.key=%s", chainID, key)
 }
 
 type FinalityProviderInfosResponse struct {

--- a/internal/packages/babylon/finality-provider/api/api.go
+++ b/internal/packages/babylon/finality-provider/api/api.go
@@ -14,7 +14,7 @@ const finalitySigTimeout = 3
 
 func GetFinalityProviderUptime(exporter *common.Exporter) (types.BabylonFinalityProviderUptimeStatues, error) {
 	// 1. get finality provider infos
-	finalityProviderInfos, err := commonapi.GetBabylonFinalityProviderInfos(exporter.CommonClient)
+	finalityProviderInfos, err := commonapi.GetBabylonFinalityProviderInfos(exporter.CommonClient, exporter.ChainID)
 	if err != nil {
 		return types.BabylonFinalityProviderUptimeStatues{}, errors.Wrap(err, "failed to get babylon finality provider infos")
 	}

--- a/internal/packages/babylon/finality-provider/indexer/batch_sync.go
+++ b/internal/packages/babylon/finality-provider/indexer/batch_sync.go
@@ -17,7 +17,7 @@ const finalitySigTimeout = 3
 
 // NOTE: in this package, the missed height means fp didn't broadcast the finality sig tx in height+1 block
 // for example, I didn't broadcast the tx at 100 block, that will make missed block for 99 height.
-func (idx *FinalityProviderIndexer) batchSync(lastIndexPointerHeight int64) (
+func (idx *FinalityProviderIndexer) batchSync(chainID string, lastIndexPointerHeight int64) (
 	/* new index pointer */ int64,
 	/* error */ error,
 ) {
@@ -135,7 +135,7 @@ func (idx *FinalityProviderIndexer) batchSync(lastIndexPointerHeight int64) (
 
 	// this logic will be progressed only when there are new tendermint validators in this block
 	if isNewFinalityProvider {
-		newfpInfoList, err := function.MakeFinalityProviderInfoList(idx.CommonClient, idx.ChainInfoID, newFinalityProviderMap)
+		newfpInfoList, err := function.MakeFinalityProviderInfoList(idx.CommonClient, chainID, idx.ChainInfoID, newFinalityProviderMap)
 		if err != nil {
 			errors.Wrap(err, "failed to make validator info list")
 		}

--- a/internal/packages/babylon/finality-provider/indexer/indexer.go
+++ b/internal/packages/babylon/finality-provider/indexer/indexer.go
@@ -132,7 +132,7 @@ func (idx *FinalityProviderIndexer) Loop(indexPoint int64) {
 		}
 
 		// trying to sync with new index pointer height
-		newIndexPointer, err := idx.batchSync(indexPoint)
+		newIndexPointer, err := idx.batchSync(idx.ChainID, indexPoint)
 		if err != nil {
 			common.Health.With(idx.RootLabels).Set(0)
 			common.Ops.With(idx.RootLabels).Inc()

--- a/internal/packages/babylon/finality-provider/indexer/indexer_test.go
+++ b/internal/packages/babylon/finality-provider/indexer/indexer_test.go
@@ -84,7 +84,7 @@ func TestBatchSync(t *testing.T) {
 	err = idx.FetchValidatorInfoList()
 	assert.NoError(t, err)
 
-	newIndexPointer, err := idx.batchSync(94810)
+	newIndexPointer, err := idx.batchSync(idx.ChainID, 94810)
 	assert.NoError(t, err)
 	t.Logf("new index point: %d", newIndexPointer)
 }
@@ -92,7 +92,8 @@ func TestBatchSync(t *testing.T) {
 func TestGetFinalityProvidersInfo(t *testing.T) {
 	app := common.NewCommonApp(p)
 	app.SetAPIEndPoint(BabylonBaseURL)
-	fpInfoList, err := api.GetBabylonFinalityProviderInfos(app.CommonClient)
+	chainID := "bbn-testnet-5"
+	fpInfoList, err := api.GetBabylonFinalityProviderInfos(app.CommonClient, chainID)
 	assert.NoError(t, err)
 	t.Logf("new fp infos: %d", len(fpInfoList))
 	for idx, fp := range fpInfoList {


### PR DESCRIPTION
## PR(Pull Request) Overview

Simple fixes for babylon v3 api changes

#### Changes

- [ ] Major feature addition or modification
- [ ] Bug fix
- [x] Code improvement
- [ ] Documentation update

#### Description of Changes
btcstaking module api path changed due to v3. Set default bsnID to chainID as input.
```
before,
"/babylon/btcstaking/v1/finality_providers" 

after
"/babylon/btcstaking/v1/finality_providers/{bsnID}"
```
#### Additional Information

If there is any additional information relevant to this PR, please include it here.
